### PR TITLE
Add utilities for visualising loss over a training run.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.vscode
 /venv
 /visualisation/plots/*
+/data
 
 *.epd
 *.txt

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /checkpoints
 /.idea
 /.vscode
+/venv
+/visualisation/plots/*
 
 *.epd
 *.txt

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 *.epd
 *.txt
 *.bin
+
+!requirements.txt

--- a/bullet-utils/src/convert.rs
+++ b/bullet-utils/src/convert.rs
@@ -5,7 +5,10 @@ use std::{
     time::Instant,
 };
 
-use bulletformat::{chess::{CudADFormat, MarlinFormat}, convert_from_bin, convert_from_text, AtaxxBoard, BulletFormat, ChessBoard};
+use bulletformat::{
+    chess::{CudADFormat, MarlinFormat},
+    convert_from_bin, convert_from_text, AtaxxBoard, BulletFormat, ChessBoard,
+};
 use structopt::StructOpt;
 
 #[derive(StructOpt)]

--- a/bullet-utils/src/count_buckets.rs
+++ b/bullet-utils/src/count_buckets.rs
@@ -29,7 +29,7 @@ impl ValidateOptions {
                 }
             };
 
-            for token in line.replace(",", "").split(" ") {
+            for token in line.replace(',', "").split(' ') {
                 match token.trim().parse::<usize>() {
                     Ok(num) => numbers.push(num),
                     Err(e) => {
@@ -43,7 +43,7 @@ impl ValidateOptions {
         let mut num_buckets: usize = 0;
         let mut buckets: [usize; 64] = [0; 64];
         for n in 0..numbers.len() {
-            buckets[n] = numbers[n] as usize;
+            buckets[n] = numbers[n];
             num_buckets = num_buckets.max(numbers[n]);
         }
 
@@ -91,8 +91,8 @@ impl ValidateOptions {
 }
 
 pub fn print_buckets(arr: [usize; 64], num_buckets: usize) {
-    for bucket in 0..num_buckets + 1 {
-        println!("Bucket {}: {}", bucket, arr[bucket as usize]);
+    for (bucket, item) in arr.iter().enumerate().take(num_buckets + 1) {
+        println!("Bucket {}: {}", bucket, item);
     }
 }
 
@@ -102,7 +102,7 @@ pub fn print_board(arr: [usize; 64]) {
         print!("| ");
         for x in 0..8 {
             let cnt = arr[(y * 8) + x];
-            print!("{} |", format!("{: >11}", cnt.to_string()))
+            print!("{: >11} |", cnt.to_string())
         }
         println!("\n+-------------+------------+------------+------------+------------+------------+------------+------------+");
     }

--- a/bullet-utils/src/count_buckets.rs
+++ b/bullet-utils/src/count_buckets.rs
@@ -2,8 +2,8 @@ use bulletformat::{ChessBoard, DataLoader};
 use structopt::StructOpt;
 
 use std::fs::File;
-use std::io::BufReader;
 use std::io::BufRead;
+use std::io::BufReader;
 use std::path::PathBuf;
 
 #[derive(StructOpt)]
@@ -11,7 +11,7 @@ pub struct ValidateOptions {
     #[structopt(required = true, min_values = 1)]
     pub inputs: Vec<PathBuf>,
     #[structopt(required = true, short, long)]
-    bucket_file: String
+    bucket_file: String,
 }
 
 impl ValidateOptions {
@@ -39,7 +39,7 @@ impl ValidateOptions {
                 }
             }
         }
-        
+
         let mut num_buckets: usize = 0;
         let mut buckets: [usize; 64] = [0; 64];
         for n in 0..numbers.len() {
@@ -86,7 +86,6 @@ impl ValidateOptions {
 
         println!("\nTotal king square counts:");
         print_board(total_king_squares);
-
     }
 }
 
@@ -97,7 +96,9 @@ pub fn print_buckets(arr: [usize; 64], num_buckets: usize) {
 }
 
 pub fn print_board(arr: [usize; 64]) {
-    println!("+-------------+------------+------------+------------+------------+------------+------------+------------+");
+    println!(
+        "+-------------+------------+------------+------------+------------+------------+------------+------------+"
+    );
     for y in (0..8).rev() {
         print!("| ");
         for x in 0..8 {

--- a/bullet-utils/src/main.rs
+++ b/bullet-utils/src/main.rs
@@ -1,8 +1,8 @@
 mod convert;
+mod count_buckets;
 mod interleave;
 mod shuffle;
 mod validate;
-mod count_buckets;
 
 use structopt::StructOpt;
 
@@ -12,7 +12,7 @@ pub enum Options {
     Interleave(interleave::InterleaveOptions),
     Shuffle(shuffle::ShuffleOptions),
     Validate(validate::ValidateOptions),
-    BucketCount(count_buckets::ValidateOptions)
+    BucketCount(count_buckets::ValidateOptions),
 }
 
 fn main() {

--- a/examples/akimbo-main.rs
+++ b/examples/akimbo-main.rs
@@ -2,8 +2,8 @@
 The exact training used for akimbo's current network, updated as I merge new nets.
 */
 use bullet_lib::{
-    inputs, outputs, Activation, Engine, LocalSettings, LrScheduler, OpeningBook, TestSettings, TimeControl,
-    TrainerBuilder, TrainingSchedule, UciOption, WdlScheduler, Loss
+    inputs, outputs, Activation, Engine, LocalSettings, Loss, LrScheduler, OpeningBook, TestSettings, TimeControl,
+    TrainerBuilder, TrainingSchedule, UciOption, WdlScheduler,
 };
 
 macro_rules! net_id {

--- a/examples/ataxx.rs
+++ b/examples/ataxx.rs
@@ -1,6 +1,6 @@
 use bullet_lib::{
-    format::AtaxxBoard, inputs::InputType, outputs, Activation, LocalSettings, LrScheduler, TrainerBuilder,
-    TrainingSchedule, WdlScheduler, Loss
+    format::AtaxxBoard, inputs::InputType, outputs, Activation, LocalSettings, Loss, LrScheduler, TrainerBuilder,
+    TrainingSchedule, WdlScheduler,
 };
 
 const HIDDEN_SIZE: usize = 128;

--- a/examples/morelayers.rs
+++ b/examples/morelayers.rs
@@ -5,7 +5,7 @@ fixed-nodes, but unfortunately was too much of a slowdown to pass any
 time-controlled test.
 */
 use bullet_lib::{
-    inputs, outputs, Activation, LocalSettings, LrScheduler, TrainerBuilder, TrainingSchedule, WdlScheduler, Loss
+    inputs, outputs, Activation, LocalSettings, Loss, LrScheduler, TrainerBuilder, TrainingSchedule, WdlScheduler,
 };
 
 fn main() {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -6,7 +6,7 @@ There's potentially a lot of elo available by adjusting the wdl
 and lr schedulers, depending on your dataset.
 */
 use bullet_lib::{
-    inputs, outputs, Activation, LocalSettings, LrScheduler, TrainerBuilder, TrainingSchedule, WdlScheduler, Loss
+    inputs, outputs, Activation, LocalSettings, Loss, LrScheduler, TrainerBuilder, TrainingSchedule, WdlScheduler,
 };
 
 const HIDDEN_SIZE: usize = 16;

--- a/examples/testnet.rs
+++ b/examples/testnet.rs
@@ -2,7 +2,7 @@
 This is used to confirm non-functional changes for bullet.
 */
 use bullet_lib::{
-    inputs, outputs, Activation, LocalSettings, LrScheduler, TrainerBuilder, TrainingSchedule, WdlScheduler, Loss
+    inputs, outputs, Activation, LocalSettings, Loss, LrScheduler, TrainerBuilder, TrainingSchedule, WdlScheduler,
 };
 
 fn main() {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+contourpy==1.2.1
+cycler==0.12.1
+fonttools==4.53.0
+kiwisolver==1.4.5
+matplotlib==3.9.0
+numpy==1.26.4
+packaging==24.0
+pandas==2.2.2
+pillow==10.3.0
+pyparsing==3.1.2
+python-dateutil==2.9.0.post0
+pytz==2024.1
+seaborn==0.13.2
+six==1.16.0
+tzdata==2024.1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use trainer::ansi;
 
 pub use bulletformat as format;
 pub use trainer::{
-    schedule::{LrScheduler, TrainingSchedule, WdlScheduler, Loss},
+    schedule::{Loss, LrScheduler, TrainingSchedule, WdlScheduler},
     set_cbcs, Trainer, TrainerBuilder,
 };
 
@@ -137,10 +137,8 @@ impl<T: inputs::InputType, U: outputs::OutputBuckets<T::RequiredDataType>> Train
         File::create(stats_path.as_str()).expect("Couldn't create stats file!");
         File::create(sched_path.as_str()).expect("Couldn't create schedule file!");
 
-        let mut sched = fs::OpenOptions::new()
-            .write(true)
-            .open(sched_path.as_str())
-            .expect("Couldn't open sschedule file!");
+        let mut sched =
+            fs::OpenOptions::new().write(true).open(sched_path.as_str()).expect("Couldn't open schedule file!");
         writeln!(&mut sched, "{schedule:#?}").expect("Couldn't write schedule to file!");
 
         let base_path_string = format!("{out_dir}/base_engine");

--- a/src/tensor/tensor_batch.rs
+++ b/src/tensor/tensor_batch.rs
@@ -211,7 +211,14 @@ impl TensorBatch {
         TensorBatch::splat_mul_matrixt_vector(handle, batch_size, weights, errors, inputs);
     }
 
-    pub fn sigmoid_mpe(&self, handle: DeviceHandles, batch_size: usize, results: &TensorBatch, error: &DeviceBuffer, power: f32) {
+    pub fn sigmoid_mpe(
+        &self,
+        handle: DeviceHandles,
+        batch_size: usize,
+        results: &TensorBatch,
+        error: &DeviceBuffer,
+        power: f32,
+    ) {
         assert_eq!(self.shape(), results.shape());
         assert_eq!(self.element_size(), results.element_size());
 

--- a/src/trainer/builder.rs
+++ b/src/trainer/builder.rs
@@ -239,6 +239,7 @@ impl<T: InputType, U: OutputBuckets<T::RequiredDataType>> TrainerBuilder<T, U> {
                 results,
                 error_device,
                 error: 0.0,
+                error_record: Vec::new(),
                 ft_reg: 0.0,
                 used: 0,
                 quantiser,

--- a/visualisation/visualise.py
+++ b/visualisation/visualise.py
@@ -1,0 +1,103 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import seaborn as sns
+import os
+import random
+
+# Set the seaborn theme for better aesthetics
+sns.set_theme()
+
+# Create the output directory if it doesn't exist
+os.makedirs("visualisation/plots", exist_ok=True)
+
+# Define the list of log files
+log_files = [
+    "checkpoints/optimiser-benchmark-16n-10/log.txt",
+    "checkpoints/optimiser-benchmark-8n-10/log.txt",
+    "checkpoints/optimiser-benchmark-4n-10/log.txt",
+    # Add more log files as needed
+]
+
+# Define the colors for each log file plot
+colors = ['blue', 'red', 'orange', 'purple', 'cyan', 'green', 'brown']
+
+# Calculate a simple moving average for smoothing
+def moving_average(data, window_size=10):
+    return np.convolve(data, np.ones(window_size)/window_size, mode='valid')
+
+# Plotting the full loss sequences
+plt.figure(figsize=(12, 6))
+
+for i, log_file in enumerate(log_files):
+    with open(log_file) as f:
+        data = f.readlines()
+
+    # Parse the loss values
+    loss_sequence = [float(l.split()[1]) for l in data]
+
+    # Smoothing the loss sequence
+    window_size = 10
+    smoothed_loss = moving_average(loss_sequence, window_size)
+
+    # Plot raw and smoothed loss
+    run_name = log_file.split("/")[-2].rstrip("-0123456789")
+    plt.plot(loss_sequence, label=f'Raw Loss {run_name}', alpha=0.3, color=colors[i % len(colors)])
+    plt.plot(range(window_size - 1, len(smoothed_loss) + window_size - 1), smoothed_loss, label=f'Smoothed Loss {run_name}', color=colors[i % len(colors)], linewidth=2)
+
+plt.title('Training Loss Over Time (Full)')
+plt.xlabel('Epoch')
+plt.ylabel('Loss')
+plt.legend()
+plt.grid(True)
+output_path_full = "visualisation/plots/training_loss_full.png"
+plt.savefig(output_path_full)
+plt.close()
+
+# Plotting the loss sequences excluding the initial few epochs
+# cutoff = 400  # Change this value as needed to adjust how many initial epochs to cut off
+
+plt.figure(figsize=(12, 6))
+
+# determine cutoff guard
+guard = 0
+for i, log_file in enumerate(log_files):
+    with open(log_file) as f:
+        data = f.readlines()
+    # dynamically determine the cutoff using a heuristic:
+    max_tail = max(loss_sequence[len(loss_sequence)//4:])
+    min_tail = min(loss_sequence[len(loss_sequence)//4:])
+    diff = max_tail - min_tail
+    this_guard = min_tail + diff * 2
+    guard = max(guard, this_guard)
+
+for i, log_file in enumerate(log_files):
+    with open(log_file) as f:
+        data = f.readlines()
+
+    # Parse the loss values
+    loss_sequence = [float(l.split()[1]) for l in data]
+
+    # Smoothing the loss sequence
+    window_size = 200
+    smoothed_loss = moving_average(loss_sequence, window_size)
+
+    # find acceptable datapoints for this run
+    last_exceeding_instance = next(i for i in reversed(range(len(loss_sequence))) if loss_sequence[i] > guard)
+    cutoff = last_exceeding_instance + 1
+
+    # Plot raw and smoothed loss excluding initial epochs
+    run_name = log_file.split("/")[-2].rstrip("-0123456789")
+    plt.plot(range(cutoff, len(loss_sequence)), loss_sequence[cutoff:], label=f'Raw Loss {run_name}', alpha=0.3, color=colors[i % len(colors)])
+    plt.plot(range(cutoff + window_size - 1, len(smoothed_loss) + window_size - 1), smoothed_loss[cutoff:], label=f'Smoothed Loss {run_name}', color=colors[i % len(colors)], linewidth=2)
+
+plt.title(f'Training Loss Over Time (Dynamically Excluding Initial Epochs)')
+plt.xlabel('Epoch')
+plt.ylabel('Loss')
+plt.legend()
+plt.grid(True)
+output_path_trimmed = "visualisation/plots/training_loss_trimmed.png"
+plt.savefig(output_path_trimmed)
+plt.close()
+
+print(f"Full plot saved to {output_path_full}")
+print(f"Trimmed plot saved to {output_path_trimmed}")


### PR DESCRIPTION
This PR does a number of things.

1. Runs `rustfmt` - sorry, this has created a bit of diff noise, but it's localised to one commit.
2. Instruments `Trainer` to track a running log of all losses during training, and dumps them to a `log.txt` file in the checkpoint folder.
3. Adds `visualisation/visualise.py`, which takes a list of logfiles and plots them together, saving plots to `visualisation/plots/`.