### PR TITLE
Add Submatrix Product Operation

### DIFF
--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -41,7 +41,7 @@ fn main() {
             batch_size: 16_384,
             batches_per_superbatch: 6104,
             start_superbatch: 1,
-            end_superbatch: 1,
+            end_superbatch: 240,
         },
         wdl_scheduler: wdl::ConstantWDL { value: 0.0 },
         lr_scheduler: lr::StepLR { start: 0.001, gamma: 0.3, step: 60 },

--- a/examples/attn.rs
+++ b/examples/attn.rs
@@ -83,7 +83,10 @@ fn build_network(inputs: usize, hl: usize, key_size: usize) -> (Graph, Node) {
 
     // inference
     let stm_acc = operations::affine(builder, l0w, stm, l0b);
+    let stm_acc = operations::activate(builder, stm_acc, Activation::CReLU);
+
     let ntm_acc = operations::affine(builder, l0w, nstm, l0b);
+    let ntm_acc = operations::activate(builder, ntm_acc, Activation::CReLU);
 
     let attn = operations::submatrix_product(builder, key_size, stm_acc, ntm_acc);
     let main_out = operations::affine(builder, l1w, attn, l1b);

--- a/examples/attn.rs
+++ b/examples/attn.rs
@@ -1,0 +1,99 @@
+use bullet_lib::{
+    inputs::{self, InputType},
+    loader, lr, operations,
+    optimiser::{AdamWOptimiser, AdamWParams},
+    outputs, wdl, Activation, ExecutionContext, Graph, GraphBuilder, LocalSettings, Node, QuantTarget, Shape, Trainer,
+    TrainingSchedule, TrainingSteps,
+};
+
+fn l2(key_size: usize, hl: usize) -> usize {
+    assert_eq!(hl % key_size, 0);
+    (hl / key_size).pow(2)
+}
+
+fn main() {
+    let inputs = inputs::Chess768;
+    let hl = 512;
+    let key_size = 64;
+    let l2 = l2(key_size, hl);
+    let num_inputs = inputs.size();
+
+    let (mut graph, output_node) = build_network(num_inputs, hl, key_size);
+
+    graph.get_weights_mut("l0w").seed_random(0.0, 1.0 / (num_inputs as f32).sqrt(), true);
+    graph.get_weights_mut("l0b").seed_random(0.0, 1.0 / (num_inputs as f32).sqrt(), true);
+    graph.get_weights_mut("l1w").seed_random(0.0, 1.0 / (2.0 * l2 as f32).sqrt(), true);
+    graph.get_weights_mut("l1b").seed_random(0.0, 1.0 / (2.0 * l2 as f32).sqrt(), true);
+
+    let mut trainer = Trainer::<AdamWOptimiser, inputs::Chess768, outputs::Single>::new(
+        graph,
+        output_node,
+        AdamWParams::default(),
+        inputs::Chess768,
+        outputs::Single,
+        vec![
+            ("l0w".to_string(), QuantTarget::I16(255)),
+            ("l0b".to_string(), QuantTarget::I16(255)),
+            ("l1w".to_string(), QuantTarget::I16(64)),
+            ("l1b".to_string(), QuantTarget::I16(64 * 255)),
+            ("pst".to_string(), QuantTarget::I16(255)),
+        ],
+        false,
+    );
+
+    let schedule = TrainingSchedule {
+        net_id: "test".to_string(),
+        eval_scale: 400.0,
+        steps: TrainingSteps {
+            batch_size: 16_384,
+            batches_per_superbatch: 6104,
+            start_superbatch: 1,
+            end_superbatch: 240,
+        },
+        wdl_scheduler: wdl::ConstantWDL { value: 0.0 },
+        lr_scheduler: lr::StepLR { start: 0.001, gamma: 0.3, step: 60 },
+        save_rate: 150,
+    };
+
+    let settings = LocalSettings { threads: 4, test_set: None, output_directory: "checkpoints", batch_queue_size: 512 };
+
+    let data_loader = loader::DirectSequentialDataLoader::new(&["data/baseline.data"]);
+
+    trainer.run(&schedule, &settings, &data_loader);
+
+    let eval = 400.0 * trainer.eval("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 | 0 | 0.0");
+    println!("Eval: {eval:.3}cp");
+}
+
+fn build_network(inputs: usize, hl: usize, key_size: usize) -> (Graph, Node) {
+    let builder = &mut GraphBuilder::default();
+    let l2 = l2(key_size, hl);
+
+    // inputs
+    let stm = builder.create_input("stm", Shape::new(inputs, 1));
+    let nstm = builder.create_input("nstm", Shape::new(inputs, 1));
+    let targets = builder.create_input("targets", Shape::new(1, 1));
+
+    // trainable weights
+    let l0w = builder.create_weights("l0w", Shape::new(hl, inputs));
+    let l0b = builder.create_weights("l0b", Shape::new(hl, 1));
+    let l1w = builder.create_weights("l1w", Shape::new(1, l2));
+    let l1b = builder.create_weights("l1b", Shape::new(1, 1));
+    let pst = builder.create_weights("pst", Shape::new(1, inputs));
+
+    // inference
+    let stm_acc = operations::affine(builder, l0w, stm, l0b);
+    let ntm_acc = operations::affine(builder, l0w, nstm, l0b);
+
+    let attn = operations::submatrix_product(builder, key_size, stm_acc, ntm_acc);
+    let main_out = operations::affine(builder, l1w, attn, l1b);
+
+    let psqt_out = operations::matmul(builder, pst, stm);
+    let predicted = operations::add(builder, main_out, psqt_out);
+
+    let sigmoided = operations::activate(builder, predicted, Activation::Sigmoid);
+    operations::mse(builder, sigmoided, targets);
+
+    // graph, output node
+    (builder.build(ExecutionContext::default()), predicted)
+}

--- a/src/backend/bindings.rs
+++ b/src/backend/bindings.rs
@@ -28,6 +28,7 @@ pub use hip::{
     hipMemcpyKind as cudaMemcpyKind, hipMemset as cudaMemset, hipblasCreate as cublasCreate_v2,
     hipblasDestroy as cublasDestroy_v2, hipblasHandle_t as cublasHandle_t, hipblasOperation_t as cublasOperation_t,
     hipblasSaxpy as cublasSaxpy_v2, hipblasSgeam as cublasSgeam, hipblasSgemm as cublasSgemm_v2,
-    hipblasSgemv as cublasSgemv_v2, hipblasSger as cublasSger_v2, hipblasStatus_t as cublasStatus_t, CUBLAS_OP_N,
-    CUBLAS_OP_T, CUBLAS_SUCCESS, D2D, D2H, H2D, SUCCESS,
+    hipblasSgemmStridedBatched as cublasSgemmStridedBatched, hipblasSgemv as cublasSgemv_v2,
+    hipblasSger as cublasSger_v2, hipblasStatus_t as cublasStatus_t, CUBLAS_OP_N, CUBLAS_OP_T, CUBLAS_SUCCESS, D2D,
+    D2H, H2D, SUCCESS,
 };

--- a/src/backend/bindings/cuda.rs
+++ b/src/backend/bindings/cuda.rs
@@ -76,6 +76,7 @@ extern "C" {
     pub fn cublasSgemm_v2(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: c_int, n: c_int, k: c_int, alpha: *const f32, A: *const f32, lda: c_int, B: *const f32, ldb: c_int, beta: *const f32, C: *mut f32, ldc: c_int) -> cublasStatus_t;
     pub fn cublasSgeam(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: c_int, n: c_int, alpha: *const f32, A: *const f32, lda: c_int, beta: *const f32, B: *const f32, ldb: c_int, C: *mut f32, ldc: c_int) -> cublasStatus_t;
     pub fn cublasSger_v2(handle: cublasHandle_t, m: c_int, n: c_int, alpha: *const f32, x: *const f32, incx: c_int, y: *const f32, incy: c_int, A: *mut f32, lda: c_int) -> cublasStatus_t;
+    pub fn cublasSgemmStridedBatched(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: c_int, n: c_int, k: c_int, alpha: *const f32, A: *const f32, lda: c_int, strideA: c_longlong, B: *const f32, ldb: ::std::os::raw::c_int, strideB: c_longlong, beta: *const f32, C: *mut f32, ldc: ::std::os::raw::c_int, strideC: c_longlong, batchCount: c_int) -> cublasStatus_t;
 }
 
 #[repr(i32)]

--- a/src/backend/bindings/hip.rs
+++ b/src/backend/bindings/hip.rs
@@ -70,6 +70,7 @@ extern "C" {
     pub fn hipblasSgemm(handle: hipblasHandle_t, transa: hipblasOperation_t, transb: hipblasOperation_t, m: c_int, n: c_int, k: c_int, alpha: *const f32, A: *const f32, lda: c_int, B: *const f32, ldb: c_int, beta: *const f32, C: *mut f32, ldc: c_int) -> hipblasStatus_t;
     pub fn hipblasSgeam(handle: hipblasHandle_t, transa: hipblasOperation_t, transb: hipblasOperation_t, m: c_int, n: c_int, alpha: *const f32, A: *const f32, lda: c_int, beta: *const f32, B: *const f32, ldb: c_int, C: *mut f32, ldc: c_int) -> hipblasStatus_t;
     pub fn hipblasSger(handle: hipblasHandle_t, m: c_int, n: c_int, alpha: *const f32, x: *const f32, incx: c_int, y: *const f32, incy: c_int, A: *mut f32, lda: c_int) -> hipblasStatus_t;
+    pub fn hipblasSgemmStridedBatched(handle: hipblasHandle_t, transA: hipblasOperation_t, transB: hipblasOperation_t, m: c_int, n: c_int, k: c_int, alpha: *const f32, AP: *const f32, lda: c_int, strideA: c_longlong, BP: *const f32, ldb: c_int, strideB: c_longlong, beta: *const f32, CP: *mut f32, ldc: c_int, strideC: c_longlong, batchCount: c_int) -> hipblasStatus_t;
 }
 
 #[repr(i32)]

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -40,6 +40,11 @@ pub fn select(builder: &mut GraphBuilder, input1: Node, input2: Node) -> Node {
     builder.create_result_of_operation(Operation::Select, &[input1, input2])
 }
 
+/// Reshapes vectors A, B with shape (n, 1) into (m, n / m) and computes A^T B
+pub fn submatrix_product(builder: &mut GraphBuilder, m: usize, input1: Node, input2: Node) -> Node {
+    builder.create_result_of_operation(Operation::SubmatrixProduct(m), &[input1, input2])
+}
+
 /// This fuses the following operations
 ///
 /// ` stm_accumulator = activate(affine(weights,  stm, bias))`

--- a/src/tensor/dense_matrix.rs
+++ b/src/tensor/dense_matrix.rs
@@ -6,9 +6,9 @@ mod conv;
 mod matmul;
 mod pairwise;
 mod power_error;
-mod submatrix_product;
 mod slice;
 mod softmax;
+mod submatrix_product;
 
 use super::shape::Shape;
 use crate::backend::Buffer;

--- a/src/tensor/dense_matrix.rs
+++ b/src/tensor/dense_matrix.rs
@@ -6,6 +6,7 @@ mod conv;
 mod matmul;
 mod pairwise;
 mod power_error;
+mod submatrix_product;
 mod slice;
 mod softmax;
 

--- a/src/tensor/dense_matrix/submatrix_product.rs
+++ b/src/tensor/dense_matrix/submatrix_product.rs
@@ -1,0 +1,167 @@
+use crate::{
+    backend::{ops, ExecutionContext},
+    Shape,
+};
+
+use super::DenseMatrix;
+
+impl DenseMatrix {
+    #[allow(clippy::too_many_arguments)]
+    fn batched_sgemm(
+        ctx: &mut ExecutionContext,
+        input_a: &Self,
+        shape_a: Shape,
+        trans_a: bool,
+        input_b: &Self,
+        shape_b: Shape,
+        trans_b: bool,
+        output: &mut Self,
+        increment: bool,
+    ) {
+        assert_eq!(shape_a.size(), input_a.shape.rows());
+        assert_eq!(shape_b.size(), input_b.shape.rows());
+        assert_eq!(input_a.shape.cols(), input_b.shape.cols());
+
+        let output_shape = shape_a.maybe_transpose(trans_a) * shape_b.maybe_transpose(trans_b);
+        let batch_size = input_a.shape.cols();
+
+        output.reshape_if_needed(Shape::new(output_shape.size(), batch_size));
+
+        unsafe {
+            ops::batched_sgemm(
+                ctx,
+                batch_size,
+                input_a.buf.ptr(),
+                shape_a.rows(),
+                shape_a.cols(),
+                trans_a,
+                input_b.buf.ptr(),
+                shape_b.rows(),
+                shape_b.cols(),
+                trans_b,
+                output.buf.mut_ptr(),
+                output_shape.rows(),
+                output_shape.cols(),
+                increment,
+            );
+        }
+    }
+
+    pub fn submatrix_product(
+        ctx: &mut ExecutionContext,
+        key_size: usize,
+        input_a: &Self,
+        input_b: &Self,
+        output: &mut Self,
+    ) {
+        assert_eq!(input_a.shape, input_b.shape);
+        assert_eq!(input_a.shape.rows() % key_size, 0);
+
+        let shape = Shape::new(key_size, input_a.shape.rows() / key_size);
+
+        Self::batched_sgemm(ctx, input_a, shape, true, input_b, shape, false, output, false);
+    }
+
+    pub fn backprop_submatrix_product(
+        ctx: &mut ExecutionContext,
+        key_size: usize,
+        input_a: &Self,
+        input_a_grad: Option<&mut Self>,
+        input_b: &Self,
+        input_b_grad: Option<&mut Self>,
+        output_grad: &Self,
+    ) {
+        assert_eq!(input_a.shape, input_b.shape);
+        assert_eq!(input_a.shape.rows() % key_size, 0);
+
+        let shape = Shape::new(key_size, input_a.shape.rows() / key_size);
+        let output_shape = shape.transpose() * shape;
+
+        assert_eq!(output_grad.shape.rows(), output_shape.size());
+
+        if let Some(grad_a) = input_a_grad {
+            Self::batched_sgemm(ctx, input_b, shape, false, output_grad, output_shape, true, grad_a, true);
+        }
+
+        if let Some(grad_b) = input_b_grad {
+            Self::batched_sgemm(ctx, input_a, shape, false, output_grad, output_shape, false, grad_b, true);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{backend::util, tensor::Shape};
+
+    #[test]
+    fn submatrix_product() {
+        let mut ctx = ExecutionContext::default();
+
+        let shape = Shape::new(2, 3);
+        let key_size = 1;
+
+        let mut input1 = DenseMatrix::default();
+        let mut input2 = DenseMatrix::default();
+        let mut input1_grad = DenseMatrix::default();
+        let mut input2_grad = DenseMatrix::default();
+        let mut output = DenseMatrix::default();
+
+        util::panic_if_device_error("Failed to initialise matrices!");
+
+        // load matrices from CPU
+        {
+            input1.load_from_slice(shape, &[1.0; 6]);
+
+            input2.load_from_slice(shape, &[2.0, 1.0, 4.0, 3.0, 0.0, 4.0]);
+
+            assert_eq!(input1.shape(), shape);
+            assert_eq!(input2.shape(), shape);
+
+            util::panic_if_device_error("Failed to load data from CPU!");
+        }
+
+        // normal matmul
+        {
+            DenseMatrix::submatrix_product(&mut ctx, key_size, &input1, &input2, &mut output);
+
+            util::panic_if_device_error("Failed to calculate matmul!");
+
+            assert_eq!(output.shape(), Shape::new(4, 3));
+
+            let mut buf = [0.0; 12];
+            output.write_to_slice(&mut buf);
+            assert_eq!(buf, [2.0, 2.0, 1.0, 1.0, 4.0, 4.0, 3.0, 3.0, 0.0, 0.0, 4.0, 4.0]);
+
+            util::panic_if_device_error("Failed to write data to CPU!");
+        }
+
+        // backprop normal matmul
+        {
+            DenseMatrix::backprop_submatrix_product(
+                &mut ctx,
+                key_size,
+                &input1,
+                Some(&mut input1_grad),
+                &input2,
+                Some(&mut input2_grad),
+                &output,
+            );
+
+            util::panic_if_device_error("Failed to backprop matmul!");
+
+            assert_eq!(input1_grad.shape(), shape);
+            assert_eq!(input2_grad.shape(), shape);
+
+            let mut grad1 = [0.0; 6];
+            input1_grad.write_to_slice(&mut grad1);
+            assert_eq!(grad1, [5.0, 5.0, 25.0, 25.0, 16.0, 16.0]);
+
+            let mut grad2 = [0.0; 6];
+            input2_grad.write_to_slice(&mut grad2);
+            assert_eq!(grad2, [4.0, 2.0, 8.0, 6.0, 0.0, 8.0]);
+
+            util::panic_if_device_error("Failed to write data to CPU!");
+        }
+    }
+}

--- a/src/tensor/operation.rs
+++ b/src/tensor/operation.rs
@@ -11,6 +11,7 @@ mod select;
 mod slice;
 mod softmax;
 mod softmax_sparse;
+mod submatrix_product;
 
 pub use activate::Activation;
 
@@ -48,6 +49,8 @@ pub enum Operation {
     SparseSoftmaxCrossEntropyLoss,
     /// Warning! Internal use only!
     SparseAffineDual(Activation),
+    /// Reshapes vectors A, B with shape (n, 1) into (m, n / m) and computes A^T B
+    SubmatrixProduct(usize),
 }
 
 impl Operation {
@@ -66,6 +69,7 @@ impl Operation {
             Operation::SoftmaxCrossEntropyLoss => softmax::output_tensor(inputs),
             Operation::SparseSoftmaxCrossEntropyLoss => softmax_sparse::output_tensor(inputs),
             Operation::SparseAffineDual(_) => affine_dual::output_tensor(inputs),
+            Operation::SubmatrixProduct(m) => submatrix_product::output_tensor(m, inputs),
         }
     }
 
@@ -84,6 +88,7 @@ impl Operation {
             Operation::SoftmaxCrossEntropyLoss => softmax::forward(ctx, inputs, output),
             Operation::SparseSoftmaxCrossEntropyLoss => softmax_sparse::forward(inputs, output),
             Operation::SparseAffineDual(activation) => affine_dual::forward(inputs, output, activation),
+            Operation::SubmatrixProduct(m) => submatrix_product::forward(ctx, m, inputs, output),
         }
     }
 
@@ -102,6 +107,7 @@ impl Operation {
             Operation::SoftmaxCrossEntropyLoss => softmax::backprop(output_grad, inputs),
             Operation::SparseSoftmaxCrossEntropyLoss => softmax_sparse::backprop(output_grad, inputs),
             Operation::SparseAffineDual(activation) => affine_dual::backprop(output_grad, inputs, activation),
+            Operation::SubmatrixProduct(m) => submatrix_product::backprop(ctx, m, output_grad, inputs),
         }
     }
 }

--- a/src/tensor/operation/submatrix_product.rs
+++ b/src/tensor/operation/submatrix_product.rs
@@ -1,0 +1,43 @@
+use crate::{
+    backend::ExecutionContext,
+    tensor::{DenseMatrix, Shape, Tensor},
+};
+
+pub fn output_tensor(m: usize, inputs: &[Shape]) -> Result<Shape, String> {
+    if inputs.len() == 2 {
+        if inputs[0] == inputs[1] {
+            if inputs[0].cols() == 1 {
+                if inputs[0].rows() % m == 0 {
+                    let shape = Shape::new(m, inputs[0].rows() / m);
+                    Ok(shape.transpose() * shape)
+                } else {
+                    Err(format!("Input vector ({}) must have dimension divisible by {m}!", inputs[0]))
+                }
+            } else {
+                Err("Input must be a vector!".to_string())
+            }
+        } else {
+            Err(format!("Inputs must have same shape! {} != {}", inputs[0], inputs[1]))
+        }
+    } else {
+        Err(format!("Invalid number of inputs in linear! Expected 2, got {}", inputs.len()))
+    }
+}
+
+pub fn forward(ctx: &mut ExecutionContext, m: usize, inputs: &[&Tensor], output: &mut Tensor) {
+    DenseMatrix::submatrix_product(ctx, m, inputs[0].values.dense(), inputs[1].values.dense(), output.values.dense_mut());
+}
+
+pub fn backprop(ctx: &mut ExecutionContext, m: usize, output: &Tensor, inputs: &mut [&mut Tensor]) {
+    let (input1, input2) = inputs.split_at_mut(1);
+
+    DenseMatrix::backprop_submatrix_product(
+        ctx,
+        m,
+        input1[0].values.dense(),
+        input1[0].gradients.as_mut(),
+        input2[0].values.dense(),
+        input2[0].gradients.as_mut(),
+        output.gradients.as_ref().unwrap(),
+    );
+}

--- a/src/tensor/operation/submatrix_product.rs
+++ b/src/tensor/operation/submatrix_product.rs
@@ -26,7 +26,13 @@ pub fn output_tensor(m: usize, inputs: &[Shape]) -> Result<Shape, String> {
 }
 
 pub fn forward(ctx: &mut ExecutionContext, m: usize, inputs: &[&Tensor], output: &mut Tensor) {
-    DenseMatrix::submatrix_product(ctx, m, inputs[0].values.dense(), inputs[1].values.dense(), output.values.dense_mut());
+    DenseMatrix::submatrix_product(
+        ctx,
+        m,
+        inputs[0].values.dense(),
+        inputs[1].values.dense(),
+        output.values.dense_mut(),
+    );
 }
 
 pub fn backprop(ctx: &mut ExecutionContext, m: usize, output: &Tensor, inputs: &mut [&mut Tensor]) {

--- a/src/tensor/operation/submatrix_product.rs
+++ b/src/tensor/operation/submatrix_product.rs
@@ -8,8 +8,9 @@ pub fn output_tensor(m: usize, inputs: &[Shape]) -> Result<Shape, String> {
         if inputs[0] == inputs[1] {
             if inputs[0].cols() == 1 {
                 if inputs[0].rows() % m == 0 {
-                    let shape = Shape::new(m, inputs[0].rows() / m);
-                    Ok(shape.transpose() * shape)
+                    let inp = Shape::new(m, inputs[0].rows() / m);
+                    let out = inp.transpose() * inp;
+                    Ok(Shape::new(out.size(), 1))
                 } else {
                     Err(format!("Input vector ({}) must have dimension divisible by {m}!", inputs[0]))
                 }

--- a/src/tensor/shape.rs
+++ b/src/tensor/shape.rs
@@ -7,14 +7,14 @@ pub struct Shape {
 
 impl std::fmt::Display for Shape {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} x {}", self.cols, self.rows)
+        write!(f, "{} x {}", self.rows, self.cols)
     }
 }
 
 impl std::ops::Mul<Shape> for Shape {
     type Output = Shape;
     fn mul(self, rhs: Shape) -> Self::Output {
-        assert_eq!(self.cols, rhs.rows);
+        assert_eq!(self.cols, rhs.rows, "{self} * {rhs} is not possible!");
 
         Self { cols: rhs.cols, rows: self.rows }
     }


### PR DESCRIPTION
Adds support for the following operation on two batches of vectors of shape `N x 1`:
`A.reshape(M x N / M).tranpose * B.reshape(M x N / M)`
I.e, performing the product between each of the `M x 1` submatrices of each vector.
This can be recognised as the main step in dot-product attention.