### PR TITLE
Factoriser Overhaul

### DIFF
--- a/src/trainer/default/builder.rs
+++ b/src/trainer/default/builder.rs
@@ -310,6 +310,8 @@ impl<T: InputType, U: OutputBuckets<T::RequiredDataType>, O: OptimiserType> Trai
             }
         }
 
+        let factorised_weights = if self.input_getter.is_factorised() { Some("l0w".to_string()) } else { None };
+
         let mut trainer = Trainer {
             optimiser: O::Optimiser::new(graph, Default::default()),
             input_getter: self.input_getter,
@@ -323,6 +325,7 @@ impl<T: InputType, U: OutputBuckets<T::RequiredDataType>, O: OptimiserType> Trai
             },
             saved_format,
             arch_description: Some(format!("{ft_desc} -> {output_desc}")),
+            factorised_weights,
         };
 
         let graph = trainer.optimiser.graph_mut();

--- a/src/trainer/default/inputs.rs
+++ b/src/trainer/default/inputs.rs
@@ -1,14 +1,16 @@
-use bulletformat::BulletFormat;
-
 mod ataxx147;
 mod chess768;
 mod chess_buckets;
 mod chess_buckets_hm;
+mod factorised;
+
+use bulletformat::BulletFormat;
 
 pub use ataxx147::{Ataxx147, Ataxx98};
 pub use chess768::Chess768;
 pub use chess_buckets::ChessBuckets;
 pub use chess_buckets_hm::{ChessBucketsMirrored, ChessBucketsMirroredFactorised};
+pub use factorised::{Factorised, Factorises};
 
 pub trait InputType: Send + Sync + Copy + Default + 'static {
     type RequiredDataType: BulletFormat + Copy + Send + Sync;
@@ -30,6 +32,15 @@ pub trait InputType: Send + Sync + Copy + Default + 'static {
     }
 
     fn feature_iter(&self, pos: &Self::RequiredDataType) -> Self::FeatureIter;
+
+    fn is_factorised(&self) -> bool {
+        false
+    }
+
+    fn merge_factoriser(&self, unmerged: Vec<f32>) -> Vec<f32> {
+        assert!(self.is_factorised());
+        unmerged
+    }
 }
 
 fn get_num_buckets<const N: usize>(arr: &[usize; N]) -> usize {

--- a/src/trainer/default/inputs/chess_buckets_hm.rs
+++ b/src/trainer/default/inputs/chess_buckets_hm.rs
@@ -1,6 +1,6 @@
 use bulletformat::{chess::BoardIter, ChessBoard};
 
-use super::{get_num_buckets, InputType};
+use super::{factorised::Factorises, get_num_buckets, Chess768, Factorised, InputType};
 
 #[derive(Clone, Copy, Debug)]
 pub struct ChessBucketsMirrored {
@@ -85,93 +85,16 @@ impl Iterator for ChessBucketsMirroredIter {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-pub struct ChessBucketsMirroredFactorised {
-    buckets: [usize; 64],
-    num_buckets: usize,
-}
-
-impl Default for ChessBucketsMirroredFactorised {
-    fn default() -> Self {
-        Self { buckets: [0; 64], num_buckets: 1 }
+impl Factorises<ChessBucketsMirrored> for Chess768 {
+    fn derive_feature(&self, _: &ChessBucketsMirrored, feat: usize) -> usize {
+        feat % 768
     }
 }
+
+pub type ChessBucketsMirroredFactorised = Factorised<ChessBucketsMirrored, Chess768>;
 
 impl ChessBucketsMirroredFactorised {
     pub fn new(buckets: [usize; 32]) -> Self {
-        let num_buckets = get_num_buckets(&buckets);
-        let buckets = {
-            let mut idx = 0;
-            let mut ret = [0; 64];
-            while idx < 64 {
-                let sq = (idx / 8) * 4 + [0, 1, 2, 3, 3, 2, 1, 0][idx % 8];
-                ret[idx] = 768 * (1 + buckets[sq]);
-                idx += 1;
-            }
-            ret
-        };
-
-        Self { buckets, num_buckets }
-    }
-}
-
-impl InputType for ChessBucketsMirroredFactorised {
-    type RequiredDataType = ChessBoard;
-    type FeatureIter = ChessBucketsMirroredFactorisedIter;
-
-    fn max_active_inputs(&self) -> usize {
-        64
-    }
-
-    fn inputs(&self) -> usize {
-        768
-    }
-
-    fn buckets(&self) -> usize {
-        self.num_buckets + 1
-    }
-
-    fn feature_iter(&self, pos: &Self::RequiredDataType) -> Self::FeatureIter {
-        let our_ksq = usize::from(pos.our_ksq());
-        let opp_ksq = usize::from(pos.opp_ksq());
-
-        ChessBucketsMirroredFactorisedIter {
-            flip: [if our_ksq % 8 > 3 { 7 } else { 0 }, if opp_ksq % 8 > 3 { 7 } else { 0 }],
-            buckets: [self.buckets[our_ksq], self.buckets[opp_ksq]],
-            board_iter: pos.into_iter(),
-            queued: None,
-        }
-    }
-}
-
-pub struct ChessBucketsMirroredFactorisedIter {
-    flip: [usize; 2],
-    buckets: [usize; 2],
-    board_iter: BoardIter,
-    queued: Option<(usize, usize)>,
-}
-
-impl Iterator for ChessBucketsMirroredFactorisedIter {
-    type Item = (usize, usize);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(feats) = self.queued {
-            self.queued = None;
-            Some(feats)
-        } else {
-            self.board_iter.next().map(|(piece, square)| {
-                let c = usize::from(piece & 8 > 0);
-                let pc = 64 * usize::from(piece & 7);
-                let sq = usize::from(square);
-
-                let our_sq = sq ^ self.flip[0];
-                let opp_sq = sq ^ self.flip[1] ^ 56;
-
-                let wfeat = self.buckets[0] + [0, 384][c] + pc + our_sq;
-                let bfeat = self.buckets[1] + [384, 0][c] + pc + opp_sq;
-                self.queued = Some((wfeat % 768, bfeat % 768));
-                (wfeat, bfeat)
-            })
-        }
+        Self::from_parts(ChessBucketsMirrored::new(buckets), Chess768)
     }
 }

--- a/src/trainer/default/inputs/factorised.rs
+++ b/src/trainer/default/inputs/factorised.rs
@@ -1,0 +1,93 @@
+use super::InputType;
+
+pub trait Factorises<T: InputType>: InputType<RequiredDataType = T::RequiredDataType> {
+    fn derive_feature(&self, input: &T, feat: usize) -> usize;
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct Factorised<A: InputType, B: Factorises<A>> {
+    normal: A,
+    factoriser: B,
+}
+
+impl<A: InputType, B: Factorises<A>> Factorised<A, B> {
+    pub fn from_parts(normal: A, factoriser: B) -> Self {
+        Self { normal, factoriser }
+    }
+}
+
+impl<A: InputType, B: Factorises<A>> InputType for Factorised<A, B> {
+    type RequiredDataType = <A as InputType>::RequiredDataType;
+    type FeatureIter = FactorisedIter<A, B>;
+
+    fn inputs(&self) -> usize {
+        self.normal.inputs()
+    }
+
+    fn buckets(&self) -> usize {
+        self.normal.buckets()
+    }
+
+    fn size(&self) -> usize {
+        self.normal.size() + self.factoriser.size()
+    }
+
+    fn max_active_inputs(&self) -> usize {
+        self.normal.max_active_inputs() + self.factoriser.max_active_inputs()
+    }
+
+    fn feature_iter(&self, pos: &Self::RequiredDataType) -> Self::FeatureIter {
+        FactorisedIter { iter: self.normal.feature_iter(pos), queued: None, offset: self.normal.size(), inputs: *self }
+    }
+
+    fn is_factorised(&self) -> bool {
+        true
+    }
+
+    fn merge_factoriser(&self, unmerged: Vec<f32>) -> Vec<f32> {
+        let tgt_size = self.normal.size();
+        let src_size = self.size();
+
+        assert_eq!(unmerged.len() % src_size, 0);
+
+        let layer_size = unmerged.len() / src_size;
+
+        (0..src_size * layer_size)
+            .map(|elem| {
+                let feat = elem / layer_size;
+                let idx = elem % layer_size;
+                let factorised_feat = self.factoriser.derive_feature(&self.normal, feat);
+                unmerged[layer_size * feat + idx] + unmerged[layer_size * (tgt_size + factorised_feat) + idx]
+            })
+            .collect()
+    }
+}
+
+pub struct FactorisedIter<A: InputType, B: Factorises<A>> {
+    iter: A::FeatureIter,
+    queued: Option<(usize, usize)>,
+    offset: usize,
+    inputs: Factorised<A, B>,
+}
+
+impl<A: InputType, B: Factorises<A>> FactorisedIter<A, B> {
+    fn map_feat(&self, feat: (usize, usize)) -> (usize, usize) {
+        (
+            self.inputs.factoriser.derive_feature(&self.inputs.normal, feat.0),
+            self.inputs.factoriser.derive_feature(&self.inputs.normal, feat.1),
+        )
+    }
+}
+
+impl<A: InputType, B: Factorises<A>> Iterator for FactorisedIter<A, B> {
+    type Item = (usize, usize);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(feats) = self.queued {
+            self.queued = None;
+            Some((self.offset + feats.0, self.offset + feats.1))
+        } else {
+            self.iter.next().inspect(|&feat| self.queued = Some(self.map_feat(feat)))
+        }
+    }
+}


### PR DESCRIPTION
This patch makes the quantised network output merge in the factoriser (if there is one), for training specified by `TrainerBuilder`.

Additionally, it adds a more generic `Factorised<MainInput, FactorisingInput>` input type to allow any `FactorisingInput` that impls `Factorises<MainInput>` to be used (and weights automatically merged in).
In particular, we now have `ChessBucketsMirroredFactorised = Factorised<ChessBucketsMirrored, Chess768>`.