### PR TITLE
Support saving quantised networks with some weight transposed.

### DIFF
--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -1,7 +1,7 @@
 use bullet_lib::{
     default::{
         inputs::{self, InputType},
-        loader, outputs, QuantTarget, Trainer,
+        loader, outputs, Layout, QuantTarget, SavedFormat, Trainer,
     },
     lr, operations,
     optimiser::{AdamWOptimiser, AdamWParams},
@@ -28,11 +28,11 @@ fn main() {
         inputs::Chess768,
         outputs::Single,
         vec![
-            ("l0w".to_string(), QuantTarget::I16(255)),
-            ("l0b".to_string(), QuantTarget::I16(255)),
-            ("l1w".to_string(), QuantTarget::I16(64)),
-            ("l1b".to_string(), QuantTarget::I16(64 * 255)),
-            ("pst".to_string(), QuantTarget::I16(255)),
+            SavedFormat::new("l0w", QuantTarget::I16(255), Layout::Normal),
+            SavedFormat::new("l0b", QuantTarget::I16(255), Layout::Normal),
+            SavedFormat::new("l1w", QuantTarget::I16(64), Layout::Normal),
+            SavedFormat::new("l1b", QuantTarget::I16(64 * 255), Layout::Normal),
+            SavedFormat::new("pst", QuantTarget::I16(255), Layout::Normal),
         ],
         false,
     );

--- a/src/trainer/default.rs
+++ b/src/trainer/default.rs
@@ -342,6 +342,12 @@ impl<Opt: Optimiser, Inp: InputType, Out: OutputBuckets<Inp::RequiredDataType>> 
                     assert!(self.input_getter.is_factorised(), "Attempting to merge in unfactorised weights!");
                     weight_buf = self.input_getter.merge_factoriser(weight_buf);
                 }
+
+                if *layout == Layout::Transposed {
+                    unimplemented!(
+                        "Transposing post-factoriser merge is not currently supported - why do you want to do this?"
+                    );
+                }
             }
 
             if let Layout::Transposed = layout {

--- a/src/trainer/default.rs
+++ b/src/trainer/default.rs
@@ -355,9 +355,6 @@ impl<Opt: Optimiser, Inp: InputType, Out: OutputBuckets<Inp::RequiredDataType>> 
                     }
                 }
 
-                println!("{weight_buf:?}");
-                println!("{new_buf:?}");
-
                 weight_buf = new_buf;
             }
 

--- a/src/trainer/default.rs
+++ b/src/trainer/default.rs
@@ -53,14 +53,32 @@ pub struct AdditionalTrainerInputs {
     dense_inputs: bool,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Layout {
+    Normal,
+    Transposed,
+}
+
+#[derive(Clone)]
+pub struct SavedFormat {
+    id: String,
+    quant: QuantTarget,
+    layout: Layout,
+}
+
+impl SavedFormat {
+    pub fn new(id: &str, quant: QuantTarget, layout: Layout) -> Self {
+        SavedFormat { id: id.to_string(), quant, layout }
+    }
+}
+
 pub struct Trainer<Opt, Inp, Out = outputs::Single> {
     optimiser: Opt,
     input_getter: Inp,
     output_getter: Out,
     output_node: Node,
     additional_inputs: AdditionalTrainerInputs,
-    saved_format: Vec<(String, QuantTarget)>,
-    arch_description: Option<String>,
+    saved_format: Vec<SavedFormat>,
     factorised_weights: Option<String>,
 }
 
@@ -134,7 +152,7 @@ impl<Opt: Optimiser, Inp: InputType, Out: OutputBuckets<Inp::RequiredDataType>> 
         params: Opt::Params,
         input_getter: Inp,
         output_getter: Out,
-        saved_format: Vec<(String, QuantTarget)>,
+        saved_format: Vec<SavedFormat>,
         dense_inputs: bool,
     ) -> Self {
         let inputs = graph.input_ids();
@@ -165,7 +183,6 @@ impl<Opt: Optimiser, Inp: InputType, Out: OutputBuckets<Inp::RequiredDataType>> 
             output_node,
             additional_inputs: AdditionalTrainerInputs { nstm, output_buckets, wdl, dense_inputs },
             saved_format,
-            arch_description: None,
             factorised_weights: None,
         }
     }
@@ -186,32 +203,6 @@ impl<Opt: Optimiser, Inp: InputType, Out: OutputBuckets<Inp::RequiredDataType>> 
     ) -> (DefaultDataLoader<Inp, Out, D>, Option<DirectLoader<Inp, Out>>) {
         logger::clear_colours();
         println!("{}", logger::ansi("Beginning Training", "34;1"));
-
-        if let Some(desc) = &self.arch_description {
-            let quantisations: Vec<_> = self
-                .saved_format
-                .iter()
-                .filter_map(|fmt| match fmt.1 {
-                    QuantTarget::I16(x) => Some(x),
-                    QuantTarget::I8(x) => Some(x),
-                    QuantTarget::I32(_) => None,
-                    QuantTarget::Float => Some(1),
-                })
-                .collect();
-
-            println!("Architecture           : {}", logger::ansi(desc, "32;1"));
-            println!("                       : {}", logger::ansi(self.input_getter.description(), "31"));
-
-            if quantisations.len() == self.saved_format.len() {
-                let desc = logger::ansi("Quantisations", "31");
-                println!("                       : {desc} {quantisations:?}");
-            }
-
-            if self.input_getter.is_factorised() {
-                let desc = logger::ansi("Factoriser weights will be merged in quantised network", "31");
-                println!("                       : {desc}");
-            }
-        }
 
         schedule.display();
         settings.display();
@@ -337,7 +328,7 @@ impl<Opt: Optimiser, Inp: InputType, Out: OutputBuckets<Inp::RequiredDataType>> 
 
         let mut buf = Vec::new();
 
-        for (id, quant) in &self.saved_format {
+        for SavedFormat { id, quant, layout } in &self.saved_format {
             let weights = self.optimiser.graph().get_weights(id);
             let weights = weights.values.dense();
 
@@ -350,6 +341,26 @@ impl<Opt: Optimiser, Inp: InputType, Out: OutputBuckets<Inp::RequiredDataType>> 
                     assert!(self.input_getter.is_factorised(), "Attempting to merge in unfactorised weights!");
                     weight_buf = self.input_getter.merge_factoriser(weight_buf);
                 }
+
+                if *layout == Layout::Transposed {
+                    unimplemented!(
+                        "Transposing post-factoriser merge is not currently supported - why do you want to do this?"
+                    );
+                }
+            }
+
+            if *layout == Layout::Transposed {
+                let cols = weights.shape().cols();
+                let rows = weights.shape().rows();
+                let mut new_buf = vec![0.0; weights.shape().size()];
+
+                for i in 0..rows {
+                    for j in 0..cols {
+                        new_buf[cols * i + j] = weight_buf[rows * j + i];
+                    }
+                }
+
+                weight_buf = new_buf;
             }
 
             let quantised = quant.quantise(&weight_buf)?;
@@ -375,7 +386,7 @@ impl<Opt: Optimiser, Inp: InputType, Out: OutputBuckets<Inp::RequiredDataType>> 
 
         let mut buf = Vec::new();
 
-        for (id, _) in &self.saved_format {
+        for SavedFormat { id, .. } in &self.saved_format {
             let weights = self.optimiser.graph().get_weights(id);
             let weights = weights.values.dense();
 

--- a/src/trainer/default.rs
+++ b/src/trainer/default.rs
@@ -38,7 +38,7 @@ use crate::{
     loader::{CanBeDirectlySequentiallyLoaded, DataLoader, DirectSequentialDataLoader},
     optimiser::Optimiser,
     trainer::NetworkTrainer,
-    Graph, Shape,
+    Graph,
 };
 
 /// Holy unsound code batman!
@@ -57,7 +57,7 @@ pub struct AdditionalTrainerInputs {
 pub enum Layout {
     Normal,
     // Reshapes and transposes
-    Transposed(Shape),
+    Transposed,
 }
 
 #[derive(Clone)]
@@ -344,16 +344,19 @@ impl<Opt: Optimiser, Inp: InputType, Out: OutputBuckets<Inp::RequiredDataType>> 
                 }
             }
 
-            if let Layout::Transposed(shape) = layout {
-                let cols = shape.cols();
-                let rows = shape.rows();
-                let mut new_buf = vec![0.0; shape.size()];
+            if let Layout::Transposed = layout {
+                let rows = weights.shape().rows();
+                let cols = weights.shape().cols();
+                let mut new_buf = vec![0.0; weights.shape().size()];
 
                 for i in 0..rows {
                     for j in 0..cols {
                         new_buf[cols * i + j] = weight_buf[rows * j + i];
                     }
                 }
+
+                println!("{weight_buf:?}");
+                println!("{new_buf:?}");
 
                 weight_buf = new_buf;
             }

--- a/src/trainer/default/builder.rs
+++ b/src/trainer/default/builder.rs
@@ -201,16 +201,12 @@ impl<T: InputType, U: OutputBuckets<T::RequiredDataType>, O: OptimiserType> Trai
 
         let mut net_quant = 1i16;
 
-        let mut push_saved_format = |layer: usize, size: usize| {
+        let mut push_saved_format = |layer: usize| {
             let w = format!("l{layer}w");
             let b = format!("l{layer}b");
 
             if let Some(quants) = &self.quantisations {
-                let layout = if layer > 0 && output_buckets {
-                    Layout::Transposed(Shape::new(U::BUCKETS, size))
-                } else {
-                    Layout::Normal
-                };
+                let layout = if layer > 0 && output_buckets { Layout::Transposed } else { Layout::Normal };
 
                 saved_format.push(SavedFormat { id: w, quant: quants[layer], layout });
 
@@ -254,7 +250,7 @@ impl<T: InputType, U: OutputBuckets<T::RequiredDataType>, O: OptimiserType> Trai
             ft_desc = format!("({ft_desc})x2");
         }
 
-        push_saved_format(0, input_size * self.ft_out_size);
+        push_saved_format(0);
 
         let mut out = builder.create_input("stm", input_shape);
 
@@ -295,7 +291,7 @@ impl<T: InputType, U: OutputBuckets<T::RequiredDataType>, O: OptimiserType> Trai
                     let w = builder.create_weights(&format!("l{layer}w"), Shape::new(raw_size, prev_size));
                     let b = builder.create_weights(&format!("l{layer}b"), Shape::new(raw_size, 1));
 
-                    push_saved_format(layer, prev_size * size);
+                    push_saved_format(layer);
 
                     layer += 1;
 

--- a/src/trainer/default/builder.rs
+++ b/src/trainer/default/builder.rs
@@ -201,12 +201,12 @@ impl<T: InputType, U: OutputBuckets<T::RequiredDataType>, O: OptimiserType> Trai
 
         let mut net_quant = 1i16;
 
-        let mut push_saved_format = |layer: usize| {
+        let mut push_saved_format = |layer: usize, size: usize| {
             let w = format!("l{layer}w");
             let b = format!("l{layer}b");
 
             if let Some(quants) = &self.quantisations {
-                let layout = if layer > 0 && output_buckets { Layout::Transposed } else { Layout::Normal };
+                let layout = if layer > 0 && output_buckets { Layout::Transposed(Shape::new(U::BUCKETS, size)) } else { Layout::Normal };
 
                 saved_format.push(SavedFormat { id: w, quant: quants[layer], layout });
 
@@ -250,7 +250,7 @@ impl<T: InputType, U: OutputBuckets<T::RequiredDataType>, O: OptimiserType> Trai
             ft_desc = format!("({ft_desc})x2");
         }
 
-        push_saved_format(0);
+        push_saved_format(0, input_size * self.ft_out_size);
 
         let mut out = builder.create_input("stm", input_shape);
 
@@ -291,7 +291,7 @@ impl<T: InputType, U: OutputBuckets<T::RequiredDataType>, O: OptimiserType> Trai
                     let w = builder.create_weights(&format!("l{layer}w"), Shape::new(raw_size, prev_size));
                     let b = builder.create_weights(&format!("l{layer}b"), Shape::new(raw_size, 1));
 
-                    push_saved_format(layer);
+                    push_saved_format(layer, prev_size * size);
 
                     layer += 1;
 

--- a/src/trainer/default/builder.rs
+++ b/src/trainer/default/builder.rs
@@ -206,7 +206,11 @@ impl<T: InputType, U: OutputBuckets<T::RequiredDataType>, O: OptimiserType> Trai
             let b = format!("l{layer}b");
 
             if let Some(quants) = &self.quantisations {
-                let layout = if layer > 0 && output_buckets { Layout::Transposed(Shape::new(U::BUCKETS, size)) } else { Layout::Normal };
+                let layout = if layer > 0 && output_buckets {
+                    Layout::Transposed(Shape::new(U::BUCKETS, size))
+                } else {
+                    Layout::Normal
+                };
 
                 saved_format.push(SavedFormat { id: w, quant: quants[layer], layout });
 


### PR DESCRIPTION
Any output bucketed architecture constructed with `TrainerBuilder` will now transpose the output weights appropriately when writing the quantised network to file.