### PR TITLE
Add option to not load the optimiser state in trainer.load_from_checkpoint()

### DIFF
--- a/examples/testnet.rs
+++ b/examples/testnet.rs
@@ -22,7 +22,7 @@ fn main() {
         .add_layer(1)
         .build();
 
-    trainer.load_from_checkpoint("checkpoints/testnet");
+    trainer.load_from_checkpoint("checkpoints/testnet", true);
 
     let schedule = TrainingSchedule {
         net_id: "testnet".to_string(),

--- a/src/optimiser.rs
+++ b/src/optimiser.rs
@@ -16,7 +16,7 @@ pub trait Optimiser {
 
     fn graph_mut(&mut self) -> &mut Graph;
 
-    fn load_from_checkpoint(&mut self, path: &str);
+    fn load_from_checkpoint(&mut self, path: &str, load_optimiser_state: bool);
 
     fn write_to_checkpoint(&self, path: &str);
 

--- a/src/optimiser/adamw.rs
+++ b/src/optimiser/adamw.rs
@@ -95,10 +95,13 @@ impl Optimiser for AdamWOptimiser {
         utils::write_weight_hashmap_to_file(&self.velocity, &format!("{path}/velocity.bin"));
     }
 
-    fn load_from_checkpoint(&mut self, path: &str) {
+    fn load_from_checkpoint(&mut self, path: &str, load_optimiser_state: bool) {
         utils::load_graph_weights_from_file(&mut self.graph, &format!("{path}/weights.bin"));
-        utils::load_weight_hashmap_from_file(self.graph.device(), &mut self.momentum, &format!("{path}/momentum.bin"));
-        utils::load_weight_hashmap_from_file(self.graph.device(), &mut self.velocity, &format!("{path}/velocity.bin"));
+
+        if load_optimiser_state {
+            utils::load_weight_hashmap_from_file(self.graph.device(), &mut self.momentum, &format!("{path}/momentum.bin"));
+            utils::load_weight_hashmap_from_file(self.graph.device(), &mut self.velocity, &format!("{path}/velocity.bin"));
+        }
     }
 
     fn set_params_for_weight(&mut self, id: &str, params: Self::Params) {

--- a/src/trainer.rs
+++ b/src/trainer.rs
@@ -48,8 +48,8 @@ pub trait NetworkTrainer {
 
     fn optimiser_mut(&mut self) -> &mut Self::Optimiser;
 
-    fn load_from_checkpoint(&mut self, path: &str) {
-        self.optimiser_mut().load_from_checkpoint(&format!("{path}/optimiser_state"));
+    fn load_from_checkpoint(&mut self, path: &str, load_optimiser_state: bool) {
+        self.optimiser_mut().load_from_checkpoint(&format!("{path}/optimiser_state"), load_optimiser_state);
     }
 
     fn save_to_checkpoint(&self, path: &str) {

--- a/src/trainer/default.rs
+++ b/src/trainer/default.rs
@@ -180,8 +180,8 @@ impl<Opt: Optimiser, Inp: SparseInputType, Out: OutputBuckets<Inp::RequiredDataT
         }
     }
 
-    pub fn load_from_checkpoint(&mut self, path: &str) {
-        <Self as NetworkTrainer>::load_from_checkpoint(self, path);
+    pub fn load_from_checkpoint(&mut self, path: &str, load_optimiser_state: bool) {
+        <Self as NetworkTrainer>::load_from_checkpoint(self, path, load_optimiser_state);
     }
 
     pub fn save_to_checkpoint(&self, path: &str) {


### PR DESCRIPTION
From my testing, people with multiple training stages can benefit from using the zeroed optimiser state, instead of loading the one from the training stage before:

STC
```
Elo   | 1.54 +- 1.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 77834 W: 18929 L: 18584 D: 40321
Penta | [281, 8997, 19991, 9392, 256]
https://chess.aronpetkovski.com/test/7711/
```
LTC
```
Elo   | 2.47 +- 1.81 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 3.00]
Games | N: 32886 W: 7875 L: 7641 D: 17370
Penta | [14, 3637, 8918, 3849, 25]
https://chess.aronpetkovski.com/test/7716/
```
Both `0076r2` and `0076r4` are a second stage net, loaded from the same first stage checkpoint, trained using the same config and the same data, with the only difference being that `0076r4` did not load the optimiser state.