### PR TITLE
New CUDA backend using `cudarc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ name = "bullet_lib"
 version = "1.0.0"
 dependencies = [
  "bullet_core",
+ "bullet_cuda_backend",
  "bullet_hip_backend",
  "bulletformat",
  "montyformat",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "bullet_cuda_backend"
+version = "0.1.0"
+dependencies = [
+ "bullet_core",
+ "cudarc",
+]
+
+[[package]]
 name = "bullet_hip_backend"
 version = "0.1.0"
 dependencies = [
@@ -124,6 +132,15 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "cudarc"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d50f5a3770c380b8b4303a5588b06a53d31a8170dc7f09cfcfb2dcb9fd807fa"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -189,6 +206,16 @@ name = "libc"
 version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
 
 [[package]]
 name = "libm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 resolver = "2"
 members = [
     "crates/bullet_core",
-    #"crates/bullet_cuda_backend",
+    "crates/bullet_cuda_backend",
     "crates/bullet_hip_backend",
     "crates/bullet_lib",
     "crates/bullet_utils",
@@ -21,7 +21,6 @@ bullet_backend = { path = "crates/bullet_backend", version = "0.1.0" }
 bullet_core = { path = "crates/bullet_core", version = "0.1.0" }
 bullet_hip_backend = { path = "crates/bullet_hip_backend", version = "0.1.0" }
 bulletformat = "1.8.0"
-cudarc = { version = "0.13.4", features = ["cuda-version-from-build-system"] }
 montyformat = "0.9.0"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
 bullet_backend = { path = "crates/bullet_backend", version = "0.1.0" }
 bullet_core = { path = "crates/bullet_core", version = "0.1.0" }
 bullet_hip_backend = { path = "crates/bullet_hip_backend", version = "0.1.0" }
+bullet_cuda_backend = { path = "crates/bullet_cuda_backend", version = "0.1.0" }
 bulletformat = "1.8.0"
 montyformat = "0.9.0"
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A domain-specific ML library, generally used for training NNUE-style networks fo
         - A small set of (composable) optimisers are included that ingest a graph and provide update methods for it
     - A token single-threaded CPU backend is included for verifying correctness of the crate and other backend implementations
     - See the [MNIST](examples/extra/mnist.rs) example for using `bullet_core` as a general-purpose ML framework
+- **bullet_cuda_backend**
+    - A working but incomplete CUDA backend rewrite, not currently suitable for serious use.
 - **bullet_hip_backend**
     - Currently contains both the HIP (for AMD GPUs) and CUDA backends. Enable the `hip` feature to use the HIP backend.
 - **bullet_lib**

--- a/crates/bullet_cuda_backend/Cargo.toml
+++ b/crates/bullet_cuda_backend/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bullet_cuda_backend"
+version = "0.1.0"
+edition = "2021"
+authors = ["Jamie Whiting"]
+
+[dependencies]
+bullet_core = { workspace = true }
+cudarc = { version = "0.14.0", features = ["cuda-version-from-build-system"] }
+
+[build-dependencies]
+cudarc = { version = "0.14.0", features = ["cuda-version-from-build-system"] }

--- a/crates/bullet_cuda_backend/build.rs
+++ b/crates/bullet_cuda_backend/build.rs
@@ -10,7 +10,7 @@ use cudarc::nvrtc;
 fn main() {
     println!("cargo:rerun-if-changed=./kernels");
 
-    let mut src = "#define CUDA_BACKEND\n".to_string();
+    let mut src = String::new();
 
     let mut file = File::open("./kernels/util.cu").unwrap();
     file.read_to_string(&mut src).unwrap();

--- a/crates/bullet_cuda_backend/build.rs
+++ b/crates/bullet_cuda_backend/build.rs
@@ -1,0 +1,37 @@
+use std::{
+    env,
+    fs::{read_dir, File},
+    io::{Read, Write},
+    path::PathBuf,
+};
+
+use cudarc::nvrtc;
+
+fn main() {
+    println!("cargo:rerun-if-changed=./kernels");
+
+    let mut src = "#define CUDA_BACKEND\n".to_string();
+
+    let mut file = File::open("./kernels/util.cu").unwrap();
+    file.read_to_string(&mut src).unwrap();
+
+    for src_file in read_dir("./kernels").unwrap().filter_map(Result::ok) {
+        let name = src_file.file_name();
+        let name = name.to_str().unwrap();
+
+        if name == "util.cu" {
+            continue;
+        }
+
+        let path = format!("./kernels/{name}");
+        file = File::open(path).unwrap();
+        file.read_to_string(&mut src).unwrap();
+    }
+
+    let ptx = nvrtc::compile_ptx(src).unwrap();
+
+    let mut out_path: PathBuf = env::var("OUT_DIR").unwrap().into();
+    out_path.push("kernels.ptx");
+    let mut out_file = File::create(out_path).unwrap();
+    write!(&mut out_file, "{}", ptx.to_src()).unwrap();
+}

--- a/crates/bullet_cuda_backend/kernels/activate.cu
+++ b/crates/bullet_cuda_backend/kernels/activate.cu
@@ -1,0 +1,76 @@
+#ifndef BULLET_CUDA_UTILS
+#define BULLET_CUDA_UTILS
+#include "util.cu"
+#endif
+
+#define ACTIVATE(name, op)\
+BULLET_KERNEL name(const int size, const float* in, float* out)\
+{\
+    buffer_operation_kernel<op>(size, in, out);\
+}\
+
+#define BACKPROP(name, op)\
+BULLET_KERNEL name(const int size, const float* input, const float* output_grad, float* input_grad)\
+{\
+    buffer_backprop_kernel<op>(size, input, output_grad, input_grad);\
+}\
+
+template<OpType op>
+__global__ void buffer_operation_kernel(const int size, const float* in, float* out)
+{
+    const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (tid < size / 4)
+    {
+        const float4 a = ((const float4 *)in)[tid];
+        ((float4 *)out)[tid] = make_float4(op(a.x), op(a.y), op(a.z), op(a.w));
+    }
+    else if (4 * tid < size)
+    {
+        for (int i = 0; i < size - 4 * tid; i++)
+        {
+            const int idx = 4 * tid + i;
+            out[idx] = op(in[idx]);
+        }
+    }
+}
+
+template<OpType op>
+__global__ void buffer_backprop_kernel(const int size, const float* input, const float* output_grad, float* input_grad)
+{
+    const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (tid < size / 4)
+    {
+        const float4 this_in = ((const float4 *)input)[tid];
+        const float4 this_out_grad = ((const float4 *)output_grad)[tid];
+        float4 curr_input_grad = ((const float4 *)input_grad)[tid];
+
+        curr_input_grad.x += op(this_in.x) * this_out_grad.x;
+        curr_input_grad.y += op(this_in.y) * this_out_grad.y;
+        curr_input_grad.z += op(this_in.z) * this_out_grad.z;
+        curr_input_grad.w += op(this_in.w) * this_out_grad.w;
+
+        ((float4 *)input_grad)[tid] = curr_input_grad;
+    }
+    else if (4 * tid < size)
+    {
+        for (int i = 0; i < size - 4 * tid; i++)
+        {
+            const int j = 4 * tid + i;
+            input_grad[j] += op(input[j]) * output_grad[j];
+        }
+    }
+}
+
+ACTIVATE(ForwardReluKernel, ReLU)
+ACTIVATE(ForwardCreluKernel, CReLU)
+ACTIVATE(ForwardScreluKernel, SCReLU)
+ACTIVATE(ForwardSqrReluKernel, SqrReLU)
+ACTIVATE(ForwardSigmoidKernel, sigmoid)
+
+BACKPROP(BackwardReluKernel, primeReLU)
+BACKPROP(BackwardCreluKernel, primeCReLU)
+BACKPROP(BackwardScreluKernel, primeSCReLU)
+BACKPROP(BackwardSqrReluKernel, primeSqrReLU)
+BACKPROP(BackwardSigmoidKernel, primeSigmoid)

--- a/crates/bullet_cuda_backend/kernels/activate.cu
+++ b/crates/bullet_cuda_backend/kernels/activate.cu
@@ -16,7 +16,7 @@ BULLET_KERNEL name(const int size, const float* input, const float* output_grad,
 }\
 
 template<OpType op>
-__global__ void buffer_operation_kernel(const int size, const float* in, float* out)
+BULLET_KERNEL_IMPL buffer_operation_kernel(const int size, const float* in, float* out)
 {
     const int tid = blockIdx.x * blockDim.x + threadIdx.x;
 
@@ -36,7 +36,7 @@ __global__ void buffer_operation_kernel(const int size, const float* in, float* 
 }
 
 template<OpType op>
-__global__ void buffer_backprop_kernel(const int size, const float* input, const float* output_grad, float* input_grad)
+BULLET_KERNEL_IMPL buffer_backprop_kernel(const int size, const float* input, const float* output_grad, float* input_grad)
 {
     const int tid = blockIdx.x * blockDim.x + threadIdx.x;
 

--- a/crates/bullet_cuda_backend/kernels/geam.cu
+++ b/crates/bullet_cuda_backend/kernels/geam.cu
@@ -1,0 +1,104 @@
+#ifndef BULLET_CUDA_UTILS
+#define BULLET_CUDA_UTILS
+#include "util.cu"
+#endif
+
+BULLET_KERNEL ScaleAssignKernel(const int size, float* params, const float alpha) {
+    const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (tid < size / 4)
+    {
+        float4 a = ((float4 *)params)[tid];
+        
+        a.x *= alpha;
+        a.y *= alpha;
+        a.z *= alpha;
+        a.w *= alpha;
+
+        ((float4 *)params)[tid] = a;
+    }
+    else if (4 * tid < size)
+    {
+        for (int i = 0; i < size - 4 * tid; i++)
+        {
+            const int j = 4 * tid + i;
+            params[j] *= alpha;
+        }
+    }
+}
+
+BULLET_KERNEL ScaleAddAssignKernel(const int size, const float alpha, float* ap, const float beta, const float* bp) {
+    const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (tid < size / 4)
+    {
+        float4 a = ((float4 *)ap)[tid];
+        const float4 b = ((const float4 *)bp)[tid];
+        
+        a.x = alpha * a.x + beta * b.x;
+        a.y = alpha * a.y + beta * b.y;
+        a.z = alpha * a.z + beta * b.z;
+        a.w = alpha * a.w + beta * b.w;
+
+        ((float4 *)ap)[tid] = a;
+    }
+    else if (4 * tid < size)
+    {
+        for (int i = 0; i < size - 4 * tid; i++)
+        {
+            const int j = 4 * tid + i;
+            ap[j] = alpha * ap[j] + beta * bp[j];
+        }
+    }
+}
+
+BULLET_KERNEL ScaleKernel(const int size, const float alpha, const float* inp, float* out) {
+    const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (tid < size / 4)
+    {
+        float4 a = ((float4 *)out)[tid];
+        const float4 b = ((const float4 *)inp)[tid];
+        
+        a.x = alpha * b.x;
+        a.y = alpha * b.y;
+        a.z = alpha * b.z;
+        a.w = alpha * b.w;
+
+        ((float4 *)out)[tid] = a;
+    }
+    else if (4 * tid < size)
+    {
+        for (int i = 0; i < size - 4 * tid; i++)
+        {
+            const int j = 4 * tid + i;
+            out[j] = alpha * inp[j];
+        }
+    }
+}
+
+BULLET_KERNEL LinearCombKernel(const int size, const float alpha, const float* ap, const float beta, const float* bp, float* cp) {
+    const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (tid < size / 4)
+    {
+        const float4 a = ((const float4 *)ap)[tid];
+        const float4 b = ((const float4 *)bp)[tid];
+        float4 c = ((float4 *)cp)[tid];
+        
+        c.x = alpha * a.x + beta * b.x;
+        c.y = alpha * a.y + beta * b.y;
+        c.z = alpha * a.z + beta * b.z;
+        c.w = alpha * a.w + beta * b.w;
+
+        ((float4 *)cp)[tid] = c;
+    }
+    else if (4 * tid < size)
+    {
+        for (int i = 0; i < size - 4 * tid; i++)
+        {
+            const int j = 4 * tid + i;
+            cp[j] = alpha * ap[j] + beta * bp[j];
+        }
+    }
+}

--- a/crates/bullet_cuda_backend/kernels/optimiser.cu
+++ b/crates/bullet_cuda_backend/kernels/optimiser.cu
@@ -5,7 +5,7 @@
 
 constexpr float Epsilon = 0.00000001F;
 
-__device__ __forceinline__ void adamOp(
+BULLET_KERNEL_IMPL adamOp(
     const float beta1,
     const float beta2,
     const float adj,

--- a/crates/bullet_cuda_backend/kernels/optimiser.cu
+++ b/crates/bullet_cuda_backend/kernels/optimiser.cu
@@ -1,0 +1,90 @@
+#ifndef BULLET_CUDA_UTILS
+#define BULLET_CUDA_UTILS
+#include "util.cu"
+#endif
+
+constexpr float Epsilon = 0.00000001F;
+
+__device__ __forceinline__ void adamOp(
+    const float beta1,
+    const float beta2,
+    const float adj,
+    const float rate,
+    const bool denom,
+    float* p,
+    float* m,
+    float* v,
+    const float* g)
+{
+    const float grad = adj * g[0];
+    m[0] = beta1 * m[0] + (1.0F - beta1) * grad;
+    v[0] = beta2 * v[0] + (1.0F - beta2) * grad * grad;
+
+    float val = m[0];
+    if (denom) val /= sqrt(v[0]) + Epsilon;
+    p[0] -= rate * val;
+}
+
+BULLET_KERNEL AdamKernel(
+    const int size,
+    const float beta1,
+    const float beta2,
+    const float adj,
+    const float rate,
+    const bool denom,
+    float* network,
+    float* momentum,
+    float* velocity,
+    const float* gradients)
+{
+    const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (tid < size / 4)
+    {
+        float4 p = ((float4 *)network)[tid];
+        float4 m = ((float4 *)momentum)[tid];
+        float4 v = ((float4 *)velocity)[tid];
+        const float4 g = ((const float4 *)gradients)[tid];
+
+        adamOp(beta1, beta2, adj, rate, denom, &p.x, &m.x, &v.x, &g.x);
+        adamOp(beta1, beta2, adj, rate, denom, &p.y, &m.y, &v.y, &g.y);
+        adamOp(beta1, beta2, adj, rate, denom, &p.z, &m.z, &v.z, &g.z);
+        adamOp(beta1, beta2, adj, rate, denom, &p.w, &m.w, &v.w, &g.w);
+
+        ((float4 *)network)[tid] = p;
+        ((float4 *)momentum)[tid] = m;
+        ((float4 *)velocity)[tid] = v;
+    }
+    else if (4 * tid < size)
+    {
+        for (int i = 0; i < size - 4 * tid; i++)
+        {
+            const int j = 4 * tid + i;
+            adamOp(beta1, beta2, adj, rate, denom, &network[j], &momentum[j], &velocity[j], &gradients[j]);
+        }
+    }
+}
+
+BULLET_KERNEL ClipKernel(const int size, float* params, const float min_weight, const float max_weight) {
+    const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (tid < size / 4)
+    {
+        float4 a = ((float4 *)params)[tid];
+        
+        a.x = min(max(a.x, min_weight), max_weight);
+        a.y = min(max(a.y, min_weight), max_weight);
+        a.z = min(max(a.z, min_weight), max_weight);
+        a.w = min(max(a.w, min_weight), max_weight);
+
+        ((float4 *)params)[tid] = a;
+    }
+    else if (4 * tid < size)
+    {
+        for (int i = 0; i < size - 4 * tid; i++)
+        {
+            const int j = 4 * tid + i;
+            params[j] = min(max(params[j], min_weight), max_weight);
+        }
+    }
+}

--- a/crates/bullet_cuda_backend/kernels/pairwise.cu
+++ b/crates/bullet_cuda_backend/kernels/pairwise.cu
@@ -1,0 +1,65 @@
+#ifndef BULLET_CUDA_UTILS
+#define BULLET_CUDA_UTILS
+#include "util.cu"
+#endif
+
+BULLET_KERNEL PairwiseMulKernel(
+    const int output_size,
+    const int batch_size,
+    const float* input,
+    float* output)
+{
+    const int tid = blockDim.x * blockIdx.x + threadIdx.x;
+
+    if (tid >= output_size * batch_size)
+        return;
+
+    const int idxInBatch = tid / output_size;
+    const int idxInOutput = tid % output_size;
+
+    const float* thisInp = input + 2 * output_size * idxInBatch + idxInOutput;
+    float* thisOut = output + output_size * idxInBatch + idxInOutput;
+
+    thisOut[0] = thisInp[0] * thisInp[output_size];
+}
+
+BULLET_KERNEL PairwiseMulBackwardKernel(
+    const int output_size,
+    const int batch_size,
+    const float* input,
+    const float* output_grad,
+    float* input_grad)
+{
+    const int tid = blockDim.x * blockIdx.x + threadIdx.x;
+
+    if (tid >= output_size * batch_size)
+        return;
+
+    const int idxInBatch = tid / output_size;
+    const int idxInOutput = tid % output_size;
+
+    const float* thisOutputGrad = output_grad + output_size * idxInBatch + idxInOutput;
+    
+    const int inputOffset = 2 * output_size * idxInBatch + idxInOutput;
+    const float* thisInput = input + inputOffset;
+    float* thisInputGrad = input_grad + inputOffset;
+
+    const float gradIn = thisOutputGrad[0];
+
+    thisInputGrad[0] += gradIn * thisInput[output_size];
+    thisInputGrad[output_size] += gradIn * thisInput[0];
+}
+
+//extern "C" void pairwiseMul(const int batch_size, const int output_size, const float* input, float* output)
+//{
+//    const int total_outputs = batch_size * output_size;
+//    const int blocks = (total_outputs + threadsPerBlock - 1) / threadsPerBlock;
+//    pairwiseMulKernel<<<blocks, threadsPerBlock>>>(output_size, batch_size, input, output);
+//}
+//
+//extern "C" void backpropPairwiseMul(const int batch_size, const int output_size, const float* input, const float* output_grad, float* input_grad)
+//{
+//    const int total_outputs = batch_size * output_size;
+//    const int blocks = (total_outputs + threadsPerBlock - 1) / threadsPerBlock;
+//    pairwiseMulBackwardKernel<<<blocks, threadsPerBlock>>>(output_size, batch_size, input, output_grad, input_grad);
+//}

--- a/crates/bullet_cuda_backend/kernels/power_error.cu
+++ b/crates/bullet_cuda_backend/kernels/power_error.cu
@@ -18,7 +18,7 @@ BULLET_KERNEL PowerErrorKernel(
     output[i] = powf(abs(inputs[i] - results[i]), power);
 }
 
-BULLET_KERNEL BackpropPowerErrorKernel(
+BULLET_KERNEL PowerErrorBackwardKernel(
     const int size,
     const float* inputs,
     const float* results,

--- a/crates/bullet_cuda_backend/kernels/power_error.cu
+++ b/crates/bullet_cuda_backend/kernels/power_error.cu
@@ -1,0 +1,37 @@
+#ifndef BULLET_CUDA_UTILS
+#define BULLET_CUDA_UTILS
+#include "util.cu"
+#endif
+
+BULLET_KERNEL PowerErrorKernel(
+    const int size,
+    const float* inputs,
+    const float* results,
+    float* output,
+    const float power)
+{
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (i >= size)
+        return;
+
+    output[i] = powf(abs(inputs[i] - results[i]), power);
+}
+
+BULLET_KERNEL BackpropPowerErrorKernel(
+    const int size,
+    const float* inputs,
+    const float* results,
+    const float* output_grad,
+    float* input_grads,
+    const float power)
+{
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (i >= size)
+        return;
+
+    const float diff = inputs[i] - results[i];
+    const float grad = power * powf(abs(diff), power - 1.0F) * output_grad[i];
+    input_grads[i] += diff > 0.0F ? grad : -grad;
+}

--- a/crates/bullet_cuda_backend/kernels/scalar.cu
+++ b/crates/bullet_cuda_backend/kernels/scalar.cu
@@ -1,0 +1,80 @@
+#ifndef BULLET_CUDA_UTILS
+#define BULLET_CUDA_UTILS
+#include "util.cu"
+#endif
+
+#define SCALAR_KERNEL_FORWARD(name, op)\
+BULLET_KERNEL name(const int size, const float alpha, const float* in, float* out)\
+{\
+    scalar_kernel_forward<op>(size, alpha, in, out);\
+}\
+
+#define SCALAR_KERNEL_BACKWARD(name, op)\
+BULLET_KERNEL name(const int size, const float alpha, const float* input, const float* output_grad, float* input_grad)\
+{\
+    scalar_kernel_backward<op>(size, alpha, input, output_grad, input_grad);\
+}\
+
+template<BinaryOpType op>
+__global__ void scalar_kernel_forward(const int size, const float alpha, const float* inp, float* out) {
+    const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (tid < size / 4)
+    {
+        float4 a = ((float4 *)out)[tid];
+        const float4 b = ((const float4 *)inp)[tid];
+        
+        a.x = op(b.x, alpha);
+        a.y = op(b.y, alpha);
+        a.z = op(b.z, alpha);
+        a.w = op(b.w, alpha);
+
+        ((float4 *)out)[tid] = a;
+    }
+    else if (4 * tid < size)
+    {
+        for (int i = 0; i < size - 4 * tid; i++)
+        {
+            const int j = 4 * tid + i;
+            out[j] = op(inp[j], alpha);
+        }
+    }
+}
+
+template<BinaryOpType op>
+__global__ void scalar_kernel_backward(const int size, const float alpha, const float* input, const float* output_grad, float* input_grad) {
+    const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (tid < size / 4)
+    {
+        const float4 this_in = ((const float4 *)input)[tid];
+        const float4 this_out_grad = ((const float4 *)output_grad)[tid];
+        float4 curr_input_grad = ((const float4 *)input_grad)[tid];
+
+        curr_input_grad.x += op(this_in.x, alpha) * this_out_grad.x;
+        curr_input_grad.y += op(this_in.y, alpha) * this_out_grad.y;
+        curr_input_grad.z += op(this_in.z, alpha) * this_out_grad.z;
+        curr_input_grad.w += op(this_in.w, alpha) * this_out_grad.w;
+
+        ((float4 *)input_grad)[tid] = curr_input_grad;
+    }
+    else if (4 * tid < size)
+    {
+        for (int i = 0; i < size - 4 * tid; i++)
+        {
+            const int j = 4 * tid + i;
+            input_grad[j] += op(input[j], alpha) * output_grad[j];
+        }
+    }
+}
+
+__device__ float add(float a, float b) { return a + b; }
+__device__ float abs_pow(float a, float b) { return powf(abs(a), b); }
+__device__ float abs_pow_backward(float a, float b) {
+    const float grad = b * powf(abs(a), b - 1.0F);
+    return a > 0.0F ? grad : -grad;
+};
+
+SCALAR_KERNEL_FORWARD(AddScalarKernel, add)
+SCALAR_KERNEL_FORWARD(AbsPowScalarKernel, abs_pow)
+SCALAR_KERNEL_BACKWARD(AbsPowScalarBackwardKernel, abs_pow_backward)

--- a/crates/bullet_cuda_backend/kernels/scalar.cu
+++ b/crates/bullet_cuda_backend/kernels/scalar.cu
@@ -16,7 +16,7 @@ BULLET_KERNEL name(const int size, const float alpha, const float* input, const 
 }\
 
 template<BinaryOpType op>
-__global__ void scalar_kernel_forward(const int size, const float alpha, const float* inp, float* out) {
+BULLET_KERNEL_IMPL scalar_kernel_forward(const int size, const float alpha, const float* inp, float* out) {
     const int tid = blockIdx.x * blockDim.x + threadIdx.x;
 
     if (tid < size / 4)
@@ -42,7 +42,7 @@ __global__ void scalar_kernel_forward(const int size, const float alpha, const f
 }
 
 template<BinaryOpType op>
-__global__ void scalar_kernel_backward(const int size, const float alpha, const float* input, const float* output_grad, float* input_grad) {
+BULLET_KERNEL_IMPL scalar_kernel_backward(const int size, const float alpha, const float* input, const float* output_grad, float* input_grad) {
     const int tid = blockIdx.x * blockDim.x + threadIdx.x;
 
     if (tid < size / 4)

--- a/crates/bullet_cuda_backend/kernels/sparse_bwd.cu
+++ b/crates/bullet_cuda_backend/kernels/sparse_bwd.cu
@@ -1,0 +1,90 @@
+#ifndef BULLET_CUDA_UTILS
+#define BULLET_CUDA_UTILS
+#include "util.cu"
+#endif
+
+#define SPARSE_MATMUL_BWD_KERNEL(name, op)\
+BULLET_KERNEL name(\
+    const int stride,\
+    const int nnz,\
+    const int m,\
+    const int k,\
+    const int* X,\
+    const float* Y,\
+    const float* Yg,\
+    float* Ag)\
+{\
+    sparse_affine_backward_kernel<op>(stride, nnz, m, k, false, X, Y, Yg, Ag, nullptr);\
+}\
+
+#define SPARSE_AFFINE_BWD_KERNEL(name, op)\
+BULLET_KERNEL name(\
+    const int stride,\
+    const int nnz,\
+    const int m,\
+    const int k,\
+    const bool Bb,\
+    const int* X,\
+    const float* Y,\
+    const float* Yg,\
+    float* Ag,\
+    float* Bg)\
+{\
+    sparse_affine_backward_kernel<op>(stride, nnz, m, k, Bb, X, Y, Yg, Ag, Bg);\
+}\
+
+template<OpType op>
+BULLET_KERNEL_IMPL sparse_affine_backward_kernel(
+    const int stride,
+    const int nnz,
+    const int m,
+    const int k,
+    const bool Bb,
+    const int* X,
+    const float* Y,
+    const float* Yg,
+    float* Ag,
+    float* Bg)
+{
+    const int loc = MaximumBlocksY * blockIdx.z + blockIdx.y;
+    const int row = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (row >= m || loc >= k)
+        return;
+
+    const int* tX = X + nnz * loc;
+    const int offset = stride * m * loc;
+
+    const float tE = op(Y[offset + row]) * Yg[offset + row];
+
+    if (Bg != nullptr && tE != 0.0F)
+    {   
+        const int offset2 = Bb ? m * loc : 0;
+        atomicAdd(&Bg[offset2 + row], tE);
+    }
+
+    for (int i = 0; i < nnz; i++)
+    {
+        const int j = tX[i];
+
+        if (j == -1)
+            break;
+
+        if (tE != 0.0F)
+            atomicAdd(&Ag[j * m + row], tE);
+    }
+}
+
+SPARSE_MATMUL_BWD_KERNEL(SparseMatmulBwd, primeInvIdentity);
+SPARSE_MATMUL_BWD_KERNEL(SparseMatmulBwdRelu, primeInvReLU);
+SPARSE_MATMUL_BWD_KERNEL(SparseMatmulBwdCrelu, primeInvCReLU);
+SPARSE_MATMUL_BWD_KERNEL(SparseMatmulBwdScrelu, primeInvSCReLU);
+SPARSE_MATMUL_BWD_KERNEL(SparseMatmulBwdSqrRelu, primeInvSqrReLU);
+SPARSE_MATMUL_BWD_KERNEL(SparseMatmulBwdSigmoid, primeInvSigmoid);
+
+SPARSE_AFFINE_BWD_KERNEL(SparseAffineBwd, primeInvIdentity);
+SPARSE_AFFINE_BWD_KERNEL(SparseAffineBwdRelu, primeInvReLU);
+SPARSE_AFFINE_BWD_KERNEL(SparseAffineBwdCrelu, primeInvCReLU);
+SPARSE_AFFINE_BWD_KERNEL(SparseAffineBwdScrelu, primeInvSCReLU);
+SPARSE_AFFINE_BWD_KERNEL(SparseAffineBwdSqrRelu, primeInvSqrReLU);
+SPARSE_AFFINE_BWD_KERNEL(SparseAffineBwdSigmoid, primeInvSigmoid);

--- a/crates/bullet_cuda_backend/kernels/sparse_fwd.cu
+++ b/crates/bullet_cuda_backend/kernels/sparse_fwd.cu
@@ -31,6 +31,34 @@ BULLET_KERNEL name(\
     sparse_affine_kernel<op>(stride, nnz, m, k, Bb, A, X, B, Y);\
 }\
 
+#define SPARSE_MATMUL_ALIGNED_FWD_KERNEL(name, op)\
+BULLET_KERNEL name(\
+    const int stride,\
+    const int nnz,\
+    const int m,\
+    const int k,\
+    const float* A,\
+    const int* X,\
+    float* Y)\
+{\
+    sparse_affine_aligned_kernel<op>(stride, nnz, m, k, false, A, X, nullptr, Y);\
+}\
+
+#define SPARSE_AFFINE_ALIGNED_FWD_KERNEL(name, op)\
+BULLET_KERNEL name(\
+    const int stride,\
+    const int nnz,\
+    const int m,\
+    const int k,\
+    const bool Bb,\
+    const float* A,\
+    const int* X,\
+    const float* B,\
+    float* Y)\
+{\
+    sparse_affine_aligned_kernel<op>(stride, nnz, m, k, Bb, A, X, B, Y);\
+}\
+
 template<OpType op>
 BULLET_KERNEL_IMPL sparse_affine_kernel(
     const int stride,
@@ -131,3 +159,17 @@ SPARSE_AFFINE_FWD_KERNEL(SparseAffineFwdCrelu, CReLU);
 SPARSE_AFFINE_FWD_KERNEL(SparseAffineFwdScrelu, SCReLU);
 SPARSE_AFFINE_FWD_KERNEL(SparseAffineFwdSqrRelu, SqrReLU);
 SPARSE_AFFINE_FWD_KERNEL(SparseAffineFwdSigmoid, sigmoid);
+
+SPARSE_MATMUL_ALIGNED_FWD_KERNEL(SparseMatmulAlignedFwd, Identity);
+SPARSE_MATMUL_ALIGNED_FWD_KERNEL(SparseMatmulAlignedFwdRelu, ReLU);
+SPARSE_MATMUL_ALIGNED_FWD_KERNEL(SparseMatmulAlignedFwdCrelu, CReLU);
+SPARSE_MATMUL_ALIGNED_FWD_KERNEL(SparseMatmulAlignedFwdScrelu, SCReLU);
+SPARSE_MATMUL_ALIGNED_FWD_KERNEL(SparseMatmulAlignedFwdSqrRelu, SqrReLU);
+SPARSE_MATMUL_ALIGNED_FWD_KERNEL(SparseMatmulAlignedFwdSigmoid, sigmoid);
+
+SPARSE_AFFINE_ALIGNED_FWD_KERNEL(SparseAffineAlignedFwd, Identity);
+SPARSE_AFFINE_ALIGNED_FWD_KERNEL(SparseAffineAlignedFwdRelu, ReLU);
+SPARSE_AFFINE_ALIGNED_FWD_KERNEL(SparseAffineAlignedFwdCrelu, CReLU);
+SPARSE_AFFINE_ALIGNED_FWD_KERNEL(SparseAffineAlignedFwdScrelu, SCReLU);
+SPARSE_AFFINE_ALIGNED_FWD_KERNEL(SparseAffineAlignedFwdSqrRelu, SqrReLU);
+SPARSE_AFFINE_ALIGNED_FWD_KERNEL(SparseAffineAlignedFwdSigmoid, sigmoid);

--- a/crates/bullet_cuda_backend/kernels/sparse_fwd.cu
+++ b/crates/bullet_cuda_backend/kernels/sparse_fwd.cu
@@ -1,0 +1,133 @@
+#ifndef BULLET_CUDA_UTILS
+#define BULLET_CUDA_UTILS
+#include "util.cu"
+#endif
+
+#define SPARSE_MATMUL_FWD_KERNEL(name, op)\
+BULLET_KERNEL name(\
+    const int stride,\
+    const int nnz,\
+    const int m,\
+    const int k,\
+    const float* A,\
+    const int* X,\
+    float* Y)\
+{\
+    sparse_affine_kernel<op>(stride, nnz, m, k, false, A, X, nullptr, Y);\
+}\
+
+#define SPARSE_AFFINE_FWD_KERNEL(name, op)\
+BULLET_KERNEL name(\
+    const int stride,\
+    const int nnz,\
+    const int m,\
+    const int k,\
+    const bool Bb,\
+    const float* A,\
+    const int* X,\
+    const float* B,\
+    float* Y)\
+{\
+    sparse_affine_kernel<op>(stride, nnz, m, k, Bb, A, X, B, Y);\
+}\
+
+template<OpType op>
+BULLET_KERNEL_IMPL sparse_affine_kernel(
+    const int stride,
+    const int nnz,
+    const int m,
+    const int k,
+    const bool Bb,
+    const float* A,
+    const int* X,
+    const float* B,
+    float* Y)
+{
+    const int loc = MaximumBlocksY * blockIdx.z + blockIdx.y;
+    const int row = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (row >= m || loc >= k)
+        return;
+
+    const int offset = Bb ? m * loc : 0;
+    float sum = B == nullptr ? 0.0F : B[offset + row];
+
+    for (int i = 0; i < nnz; i++) {
+        const int j = X[nnz * loc + i];
+
+        if (j == -1)
+            break;
+
+        sum += A[j * m + row];
+    }
+
+    Y[stride * m * loc + row] = op(sum);
+}
+
+template<OpType op>
+BULLET_KERNEL_IMPL sparse_affine_aligned_kernel(
+    const int stride,
+    const int nnz,
+    const int m,
+    const int k,
+    const bool Bb,
+    const float* A,
+    const int* X,
+    const float* B,
+    float* Y)
+{
+    extern __shared__ int sX[];
+    const int loc = MaximumBlocksY * blockIdx.z + blockIdx.y;
+    const int row = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (4 * row >= m || loc >= k)
+        return;
+
+    if (threadIdx.x < nnz)
+    {
+        for (int i = threadIdx.x; i < nnz; i += blockDim.x)
+        {
+            sX[i] = X[nnz * loc + i];
+        }
+    }
+
+    __syncthreads();
+
+    const int offset = Bb ? m * loc / 4 : 0;
+    float4 val = B == nullptr ? make_float4(0.0F, 0.0F, 0.0F, 0.0F) : reinterpret_cast<const float4*>(B)[offset + row];
+
+    for (int i = 0; i < nnz; i++) {
+        const int j = sX[i];
+
+        if (j == -1)
+            break;
+
+        const float4 a = reinterpret_cast<const float4*>(A)[j * m / 4 + row];
+
+        val.x += a.x;
+        val.y += a.y;
+        val.z += a.z;
+        val.w += a.w;
+    }
+
+    val.x = op(val.x);
+    val.y = op(val.y);
+    val.z = op(val.z);
+    val.w = op(val.w);
+
+    reinterpret_cast<float4*>(Y)[stride * m * loc / 4 + row] = val;
+}
+
+SPARSE_MATMUL_FWD_KERNEL(SparseMatmulFwd, Identity);
+SPARSE_MATMUL_FWD_KERNEL(SparseMatmulFwdRelu, ReLU);
+SPARSE_MATMUL_FWD_KERNEL(SparseMatmulFwdCrelu, CReLU);
+SPARSE_MATMUL_FWD_KERNEL(SparseMatmulFwdScrelu, SCReLU);
+SPARSE_MATMUL_FWD_KERNEL(SparseMatmulFwdSqrRelu, SqrReLU);
+SPARSE_MATMUL_FWD_KERNEL(SparseMatmulFwdSigmoid, sigmoid);
+
+SPARSE_AFFINE_FWD_KERNEL(SparseAffineFwd, Identity);
+SPARSE_AFFINE_FWD_KERNEL(SparseAffineFwdRelu, ReLU);
+SPARSE_AFFINE_FWD_KERNEL(SparseAffineFwdCrelu, CReLU);
+SPARSE_AFFINE_FWD_KERNEL(SparseAffineFwdScrelu, SCReLU);
+SPARSE_AFFINE_FWD_KERNEL(SparseAffineFwdSqrRelu, SqrReLU);
+SPARSE_AFFINE_FWD_KERNEL(SparseAffineFwdSigmoid, sigmoid);

--- a/crates/bullet_cuda_backend/kernels/util.cu
+++ b/crates/bullet_cuda_backend/kernels/util.cu
@@ -1,10 +1,5 @@
 #define BULLET_CUDA_UTILS
-
-#ifdef CUDA_BACKEND
 #define BULLET_KERNEL extern "C" __global__ void
-#else
-#define BULLET_KERNEL __global__ void
-#endif
 
 typedef float(*OpType)(float);
 typedef float(*BinaryOpType)(float, float);

--- a/crates/bullet_cuda_backend/kernels/util.cu
+++ b/crates/bullet_cuda_backend/kernels/util.cu
@@ -1,0 +1,34 @@
+#define BULLET_CUDA_UTILS
+
+#ifdef CUDA_BACKEND
+#define BULLET_KERNEL extern "C" __global__ void
+#else
+#define BULLET_KERNEL __global__ void
+#endif
+
+typedef float(*OpType)(float);
+typedef float(*BinaryOpType)(float, float);
+
+__device__ float Identity([[maybe_unused]] float in) { return in; }
+__device__ float ReLU(float in) { return in > 0.0F ? in : 0.0F; }
+__device__ float CReLU(float in) { return in < 0.0F ? 0.0F : (in > 1.0F ? 1.0F : in); }
+__device__ float SCReLU(float in) { return in < 0.0F ? 0.0F : (in > 1.0F ? 1.0F : (in * in)); }
+__device__ float SqrReLU(float in) { return in < 0.0F ? 0.0F : (in * in); }
+__device__ float sigmoid(float in) { return 1.0F / (1.0F + expf(-in)); }
+
+__device__ float primeIdentity([[maybe_unused]] float in) { return 1.0F; }
+__device__ float primeReLU(float in) { return in > 0.0F ? 1.0F : 0.0F; }
+__device__ float primeCReLU(float in) { return in > 0.0F && in < 1.0F ? 1.0F : 0.0F; }
+__device__ float primeSCReLU(float in) { return in > 0.0F && in < 1.0F ? 2.0F * in : 0.0F; }
+__device__ float primeSqrReLU(float in) { return in > 0.0F ? 2.0F * in : 0.0F; }
+__device__ float primeSigmoid(float in) {
+    const float act = sigmoid(in);
+    return act * (1.0F - act);
+}
+
+__device__ float primeInvIdentity([[maybe_unused]] float in) { return 1.0F; }
+__device__ float primeInvReLU(float in) { return in > 0.0F ? 1.0F : 0.0F; }
+__device__ float primeInvCReLU(float in) { return in > 0.0F && in < 1.0F ? 1.0F : 0.0F; }
+__device__ float primeInvSCReLU(float in) { return in > 0.0F && in < 1.0F ? 2.0F * sqrtf(in) : 0.0F; }
+__device__ float primeInvSqrReLU(float in) { return in > 0.0F ? 2.0F * sqrtf(in) : 0.0F; }
+__device__ float primeInvSigmoid(float in) { return in * (1.0F - in); }

--- a/crates/bullet_cuda_backend/kernels/util.cu
+++ b/crates/bullet_cuda_backend/kernels/util.cu
@@ -1,8 +1,11 @@
 #define BULLET_CUDA_UTILS
 #define BULLET_KERNEL extern "C" __global__ void
+#define BULLET_KERNEL_IMPL __device__ __forceinline__ void
 
 typedef float(*OpType)(float);
 typedef float(*BinaryOpType)(float, float);
+
+constexpr int MaximumBlocksY = 32768;
 
 __device__ float Identity([[maybe_unused]] float in) { return in; }
 __device__ float ReLU(float in) { return in > 0.0F ? in : 0.0F; }

--- a/crates/bullet_cuda_backend/src/base.rs
+++ b/crates/bullet_cuda_backend/src/base.rs
@@ -175,6 +175,8 @@ impl BaseOperations for CudaBuffer<f32> {
         }
 
         let output_size = size / 2;
+        let total_size = batch_size * output_size;
+
         let func = self.device.module.load_function("PairwiseMulBackwardKernel").map_err(CudaError::Driver)?;
 
         unsafe {
@@ -183,10 +185,10 @@ impl BaseOperations for CudaBuffer<f32> {
                 .launch_builder(&func)
                 .arg(&(output_size as i32))
                 .arg(&(batch_size as i32))
-                .arg(&a.buf.slice(0..size))
-                .arg(&grd.buf.slice(0..size))
-                .arg(&mut self.buf.slice_mut(0..size))
-                .launch(CudaDevice::elementwise_launch_params_single(batch_size * output_size, 1024))
+                .arg(&a.buf.slice(0..2 * total_size))
+                .arg(&grd.buf.slice(0..2 * total_size))
+                .arg(&mut self.buf.slice_mut(0..total_size))
+                .launch(CudaDevice::elementwise_launch_params_single(total_size, 1024))
                 .map_err(CudaError::Driver)?;
         }
 

--- a/crates/bullet_cuda_backend/src/base.rs
+++ b/crates/bullet_cuda_backend/src/base.rs
@@ -148,6 +148,8 @@ impl BaseOperations for CudaBuffer<f32> {
         }
 
         let output_size = size / 2;
+        let total_size = batch_size * output_size;
+
         let func = self.device.module.load_function("PairwiseMulKernel").map_err(CudaError::Driver)?;
 
         unsafe {
@@ -156,9 +158,9 @@ impl BaseOperations for CudaBuffer<f32> {
                 .launch_builder(&func)
                 .arg(&(output_size as i32))
                 .arg(&(batch_size as i32))
-                .arg(&a.buf.slice(0..size))
-                .arg(&mut self.buf.slice_mut(0..size))
-                .launch(CudaDevice::elementwise_launch_params_single(batch_size * output_size, 1024))
+                .arg(&a.buf.slice(0..2 * total_size))
+                .arg(&mut self.buf.slice_mut(0..total_size))
+                .launch(CudaDevice::elementwise_launch_params_single(total_size, 1024))
                 .map_err(CudaError::Driver)?;
         }
 

--- a/crates/bullet_cuda_backend/src/base.rs
+++ b/crates/bullet_cuda_backend/src/base.rs
@@ -1,0 +1,196 @@
+use bullet_core::{
+    backend::device::base::{AdamConfig, BaseOperations},
+    graph::ir::op::DiffableFromOutput,
+};
+use cudarc::driver::{LaunchConfig, PushKernelArg};
+
+use crate::{CudaBuffer, CudaError};
+
+#[allow(unused)]
+impl BaseOperations for CudaBuffer<f32> {
+    type BaseError = CudaError;
+
+    fn diffable_from_output_fwd(
+        &mut self,
+        size: usize,
+        a: &Self,
+        act: DiffableFromOutput,
+    ) -> Result<(), Self::BaseError> {
+        let func_name = match act {
+            DiffableFromOutput::Identity => panic!("No-op!"),
+            DiffableFromOutput::ReLU => "ForwardReluKernel",
+            DiffableFromOutput::CReLU => "ForwardCreluKernel",
+            DiffableFromOutput::SCReLU => "ForwardScreluKernel",
+            DiffableFromOutput::SqrReLU => "ForwardSqrReluKernel",
+            DiffableFromOutput::Sigmoid => "ForwardSigmoidKernel",
+        };
+
+        let threads = 512;
+        let float4_size = (size as u32 + 3) / 4;
+        let blocks = float4_size.div_ceil(threads);
+
+        let func = self.device.module.load_function(func_name).map_err(CudaError::Driver)?;
+
+        unsafe {
+            self.device
+                .stream
+                .launch_builder(&func)
+                .arg(&(size as i32))
+                .arg(&a.buf.slice(0..size))
+                .arg(&mut self.buf.slice_mut(0..size))
+                .launch(LaunchConfig { grid_dim: (blocks, 1, 1), block_dim: (threads, 1, 1), shared_mem_bytes: 0 })
+                .map_err(CudaError::Driver)?;
+        }
+
+        Ok(())
+    }
+
+    fn diffable_from_output_bwd(
+        &mut self,
+        size: usize,
+        a: &Self,
+        grd: &Self,
+        act: DiffableFromOutput,
+    ) -> Result<(), Self::BaseError> {
+        let func_name = match act {
+            DiffableFromOutput::Identity => panic!("No-op!"),
+            DiffableFromOutput::ReLU => "BackwardReluKernel",
+            DiffableFromOutput::CReLU => "BackwardCreluKernel",
+            DiffableFromOutput::SCReLU => "BackwardScreluKernel",
+            DiffableFromOutput::SqrReLU => "BackwardSqrReluKernel",
+            DiffableFromOutput::Sigmoid => "BackwardSigmoidKernel",
+        };
+
+        let threads = 512;
+        let float4_size = (size as u32 + 3) / 4;
+        let blocks = float4_size.div_ceil(threads);
+
+        let func = self.device.module.load_function(func_name).map_err(CudaError::Driver)?;
+
+        unsafe {
+            self.device
+                .stream
+                .launch_builder(&func)
+                .arg(&(size as i32))
+                .arg(&a.buf.slice(0..size))
+                .arg(&grd.buf.slice(0..size))
+                .arg(&mut self.buf.slice_mut(0..size))
+                .launch(LaunchConfig { grid_dim: (blocks, 1, 1), block_dim: (threads, 1, 1), shared_mem_bytes: 0 })
+                .map_err(CudaError::Driver)?;
+        }
+
+        Ok(())
+    }
+
+    fn add_scalar(&mut self, size: usize, alpha: f32, input: &Self) -> Result<(), Self::BaseError> {
+        Ok(())
+    }
+
+    fn abs_pow_scalar(&mut self, size: usize, alpha: f32, input: &Self) -> Result<(), Self::BaseError> {
+        Ok(())
+    }
+
+    fn abs_pow_scalar_backward(
+        &mut self,
+        size: usize,
+        alpha: f32,
+        input: &Self,
+        grd: &Self,
+    ) -> Result<(), Self::BaseError> {
+        Ok(())
+    }
+
+    fn pairwise_fwd(&mut self, size: usize, batch_size: usize, a: &Self) -> Result<(), Self::BaseError> {
+        Ok(())
+    }
+
+    fn pairwise_bwd(&mut self, size: usize, batch_size: usize, a: &Self, grd: &Self) -> Result<(), Self::BaseError> {
+        Ok(())
+    }
+
+    fn power_error_fwd(&mut self, power: f32, size: usize, a: &Self, b: &Self) -> Result<(), Self::BaseError> {
+        Ok(())
+    }
+
+    fn power_error_bwd(
+        &mut self,
+        power: f32,
+        size: usize,
+        a: &Self,
+        b: &Self,
+        grd: &Self,
+    ) -> Result<(), Self::BaseError> {
+        Ok(())
+    }
+
+    fn copy_or_add_strided(
+        &mut self,
+        add: bool,
+        rows: usize,
+        cols: usize,
+        offset: usize,
+        stride: usize,
+        a: &Self,
+        offset_a: usize,
+        stride_a: usize,
+    ) -> Result<(), Self::BaseError> {
+        Ok(())
+    }
+
+    fn clip(&mut self, size: usize, min: f32, max: f32) -> Result<(), Self::BaseError> {
+        let threads = 1024;
+        let float4_size = (size as u32 + 3) / 4;
+        let blocks = float4_size.div_ceil(threads);
+
+        let func = self.device.module.load_function("ClipKernel").map_err(CudaError::Driver)?;
+
+        unsafe {
+            self.device
+                .stream
+                .launch_builder(&func)
+                .arg(&(size as i32))
+                .arg(&mut self.buf.slice_mut(0..size))
+                .arg(&min)
+                .arg(&max)
+                .launch(LaunchConfig { grid_dim: (blocks, 1, 1), block_dim: (threads, 1, 1), shared_mem_bytes: 0 })
+                .map_err(CudaError::Driver)?;
+        }
+
+        Ok(())
+    }
+
+    fn adam(
+        &mut self,
+        config: &AdamConfig,
+        size: usize,
+        grd: &Self,
+        mom: &mut Self,
+        vel: &mut Self,
+    ) -> Result<(), Self::BaseError> {
+        let threads = 1024;
+        let float4_size = (size as u32 + 3) / 4;
+        let blocks = float4_size.div_ceil(threads);
+
+        let func = self.device.module.load_function("AdamKernel").map_err(CudaError::Driver)?;
+
+        unsafe {
+            self.device
+                .stream
+                .launch_builder(&func)
+                .arg(&(size as i32))
+                .arg(&config.beta1)
+                .arg(&config.beta2)
+                .arg(&config.gradient_factor)
+                .arg(&config.learning_rate)
+                .arg(&config.denom)
+                .arg(&mut self.buf.slice_mut(0..size))
+                .arg(&mut mom.buf.slice_mut(0..size))
+                .arg(&mut vel.buf.slice_mut(0..size))
+                .arg(&grd.buf.slice(0..size))
+                .launch(LaunchConfig { grid_dim: (blocks, 1, 1), block_dim: (threads, 1, 1), shared_mem_bytes: 0 })
+                .map_err(CudaError::Driver)?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/bullet_cuda_backend/src/blas.rs
+++ b/crates/bullet_cuda_backend/src/blas.rs
@@ -1,0 +1,187 @@
+use bullet_core::{
+    backend::device::{blas, DeviceBuffer},
+    graph::ir::shape::Shape,
+};
+use cudarc::{
+    cublas::{
+        sys::cublasOperation_t::{CUBLAS_OP_N, CUBLAS_OP_T},
+        Gemm, GemmConfig, StridedBatchedConfig,
+    },
+    driver::{LaunchConfig, PushKernelArg},
+};
+
+use crate::{CudaBuffer, CudaError};
+
+#[allow(unused)]
+impl blas::BlasOperations for CudaBuffer<f32> {
+    type BlasError = CudaError;
+
+    fn gemm(&mut self, config: &blas::GemmConfig, a: &Self, b: &Self) -> Result<(), Self::BlasError> {
+        let (cfg, _) = convert_config(config);
+
+        unsafe { self.device.blas.gemm(cfg, &a.buf, &b.buf, &mut self.buf).map_err(CudaError::Blas) }
+    }
+
+    fn gebmm(
+        &mut self,
+        config: &blas::GemmConfig,
+        batch_size: usize,
+        a: &Self,
+        b: &Self,
+    ) -> Result<(), Self::BlasError> {
+        let (gemm, shape_o) = convert_config(config);
+
+        let cfg = StridedBatchedConfig {
+            gemm,
+            batch_size: batch_size as i32,
+            stride_a: config.shape_a.size() as i64,
+            stride_b: config.shape_b.size() as i64,
+            stride_c: shape_o.size() as i64,
+        };
+
+        unsafe { self.device.blas.gemm_strided_batched(cfg, &a.buf, &b.buf, &mut self.buf).map_err(CudaError::Blas) }
+    }
+
+    fn geam(
+        &mut self,
+        size: usize,
+        alpha: f32,
+        a: Option<&Self>,
+        beta: f32,
+        b: Option<&Self>,
+    ) -> Result<(), Self::BlasError> {
+        let threads = 1024;
+        let float4_size = (size as u32 + 3) / 4;
+        let blocks = float4_size.div_ceil(threads);
+
+        let output = match (a, b) {
+            (None, None) => {
+                if size > self.size() {
+                    return Err(CudaError::ExpectedIllegalAddressAccess);
+                }
+
+                let func = self.device.module.load_function("ScaleAssignKernel").map_err(CudaError::Driver)?;
+
+                unsafe {
+                    self.device
+                        .stream
+                        .launch_builder(&func)
+                        .arg(&(size as i32))
+                        .arg(&mut self.buf.slice_mut(0..size))
+                        .arg(&alpha)
+                        .launch(LaunchConfig {
+                            grid_dim: (blocks, 1, 1),
+                            block_dim: (threads, 1, 1),
+                            shared_mem_bytes: 0,
+                        })
+                }
+            }
+            (None, Some(b)) => {
+                if size > self.size() || size > b.size() {
+                    return Err(CudaError::ExpectedIllegalAddressAccess);
+                }
+
+                let func = self.device.module.load_function("ScaleAddAssignKernel").map_err(CudaError::Driver)?;
+
+                unsafe {
+                    self.device
+                        .stream
+                        .launch_builder(&func)
+                        .arg(&(size as i32))
+                        .arg(&alpha)
+                        .arg(&mut self.buf.slice_mut(0..size))
+                        .arg(&beta)
+                        .arg(&b.buf.slice(0..size))
+                        .launch(LaunchConfig {
+                            grid_dim: (blocks, 1, 1),
+                            block_dim: (threads, 1, 1),
+                            shared_mem_bytes: 0,
+                        })
+                }
+            }
+            (Some(a), Some(b)) => {
+                if size > self.size() || size > a.size() || size > b.size() {
+                    return Err(CudaError::ExpectedIllegalAddressAccess);
+                }
+
+                let func = self.device.module.load_function("LinearCombKernel").map_err(CudaError::Driver)?;
+
+                unsafe {
+                    self.device
+                        .stream
+                        .launch_builder(&func)
+                        .arg(&(size as i32))
+                        .arg(&alpha)
+                        .arg(&a.buf.slice(0..size))
+                        .arg(&beta)
+                        .arg(&b.buf.slice(0..size))
+                        .arg(&mut self.buf.slice_mut(0..size))
+                        .launch(LaunchConfig {
+                            grid_dim: (blocks, 1, 1),
+                            block_dim: (threads, 1, 1),
+                            shared_mem_bytes: 0,
+                        })
+                }
+            }
+            (Some(a), None) => {
+                if size > self.size() || size > a.size() {
+                    return Err(CudaError::ExpectedIllegalAddressAccess);
+                }
+
+                let func = self.device.module.load_function("ScaleKernel").map_err(CudaError::Driver)?;
+
+                unsafe {
+                    self.device
+                        .stream
+                        .launch_builder(&func)
+                        .arg(&(size as i32))
+                        .arg(&alpha)
+                        .arg(&a.buf.slice(0..size))
+                        .arg(&mut self.buf.slice_mut(0..size))
+                        .launch(LaunchConfig {
+                            grid_dim: (blocks, 1, 1),
+                            block_dim: (threads, 1, 1),
+                            shared_mem_bytes: 0,
+                        })
+                }
+            }
+        };
+
+        output.map_err(CudaError::Driver)?;
+
+        Ok(())
+    }
+}
+
+fn convert_config(config: &blas::GemmConfig) -> (GemmConfig<f32>, Shape) {
+    let blas::GemmConfig { alpha, beta, shape_a, trans_a, shape_b, trans_b } = *config;
+    let shape_o = shape_a.maybe_transpose(trans_a) * shape_b.maybe_transpose(trans_b);
+
+    let m = if trans_a { shape_a.cols() } else { shape_a.rows() };
+    let n = if trans_b { shape_b.rows() } else { shape_b.cols() };
+    let k = if trans_a { shape_a.rows() } else { shape_a.cols() };
+
+    if trans_b {
+        assert_eq!(shape_b.cols(), k);
+    } else {
+        assert_eq!(shape_b.rows(), k);
+    }
+
+    assert_eq!(shape_o.rows(), m);
+    assert_eq!(shape_o.cols(), n);
+
+    let transa = if trans_a { CUBLAS_OP_T } else { CUBLAS_OP_N };
+    let transb = if trans_b { CUBLAS_OP_T } else { CUBLAS_OP_N };
+
+    let m = m as i32;
+    let n = n as i32;
+    let k = k as i32;
+
+    let lda = shape_a.rows() as i32;
+    let ldb = shape_b.rows() as i32;
+    let ldc = shape_o.rows() as i32;
+
+    let cfg = GemmConfig { transa, transb, m, n, k, alpha, lda, ldb, beta, ldc };
+
+    (cfg, shape_o)
+}

--- a/crates/bullet_cuda_backend/src/buffer.rs
+++ b/crates/bullet_cuda_backend/src/buffer.rs
@@ -1,0 +1,50 @@
+use std::sync::Arc;
+
+use bullet_core::backend::device::DeviceBuffer;
+use cudarc::driver::{CudaSlice, DeviceRepr, ValidAsZeroBits};
+
+use crate::{CudaDevice, CudaError};
+
+pub struct CudaBuffer<T> {
+    pub(crate) buf: CudaSlice<T>,
+    pub(crate) device: Arc<CudaDevice>,
+}
+
+impl<T: DeviceRepr + ValidAsZeroBits> DeviceBuffer<CudaDevice, T> for CudaBuffer<T> {
+    type BufferError = CudaError;
+
+    fn new(device: Arc<CudaDevice>, size: usize) -> Result<Self, Self::BufferError> {
+        device
+            .stream
+            .alloc_zeros::<T>(size)
+            .map(|ok| Self { buf: ok, device: device.clone() })
+            .map_err(CudaError::Driver)
+    }
+
+    fn device(&self) -> Arc<CudaDevice> {
+        self.device.clone()
+    }
+
+    fn size(&self) -> usize {
+        self.buf.len()
+    }
+
+    fn set_zero(&mut self) -> Result<(), Self::BufferError> {
+        self.device.stream.memset_zeros(&mut self.buf).map_err(CudaError::Driver)
+    }
+
+    fn load_from_device(&mut self, buf: &Self, num: usize) -> Result<(), Self::BufferError> {
+        self.device
+            .stream
+            .memcpy_dtod(&buf.buf.slice(0..num), &mut self.buf.slice_mut(0..num))
+            .map_err(CudaError::Driver)
+    }
+
+    fn load_from_slice(&mut self, buf: &[T]) -> Result<(), Self::BufferError> {
+        self.device.stream.memcpy_htod(buf, &mut self.buf.slice_mut(0..buf.len())).map_err(CudaError::Driver)
+    }
+
+    fn write_into_slice(&self, buf: &mut [T], num: usize) -> Result<(), Self::BufferError> {
+        self.device.stream.memcpy_dtoh(&self.buf.slice(0..num), &mut buf[..num]).map_err(CudaError::Driver)
+    }
+}

--- a/crates/bullet_cuda_backend/src/device.rs
+++ b/crates/bullet_cuda_backend/src/device.rs
@@ -6,7 +6,7 @@ use bullet_core::{
 };
 use cudarc::{
     cublas::{result::CublasError, CudaBlas},
-    driver::{CudaContext, CudaModule, CudaStream, DriverError},
+    driver::{CudaContext, CudaModule, CudaStream, DriverError, LaunchConfig},
     nvrtc::Ptx,
 };
 
@@ -23,6 +23,19 @@ pub struct CudaDevice {
     pub(crate) stream: Arc<CudaStream>,
     pub(crate) blas: CudaBlas,
     pub(crate) module: Arc<CudaModule>,
+}
+
+impl CudaDevice {
+    pub fn elementwise_launch_params(size: usize, threads: u32) -> LaunchConfig {
+        let float4_size = (size as u32 + 3) / 4;
+        let blocks = float4_size.div_ceil(threads);
+        LaunchConfig { grid_dim: (blocks, 1, 1), block_dim: (threads, 1, 1), shared_mem_bytes: 0 }
+    }
+
+    pub fn elementwise_launch_params_single(size: usize, threads: u32) -> LaunchConfig {
+        let blocks = (size as u32).div_ceil(threads);
+        LaunchConfig { grid_dim: (blocks, 1, 1), block_dim: (threads, 1, 1), shared_mem_bytes: 0 }
+    }
 }
 
 #[allow(unused)]

--- a/crates/bullet_cuda_backend/src/device.rs
+++ b/crates/bullet_cuda_backend/src/device.rs
@@ -1,0 +1,231 @@
+use std::sync::Arc;
+
+use bullet_core::{
+    backend::device::{Device, OperationError, OperationResult},
+    graph::ir::{op::DiffableFromOutput, shape::Shape},
+};
+use cudarc::{
+    cublas::{result::CublasError, CudaBlas},
+    driver::{CudaContext, CudaModule, CudaStream, DriverError},
+    nvrtc::Ptx,
+};
+
+use crate::CudaBuffer;
+
+#[derive(Debug)]
+pub enum CudaError {
+    Driver(DriverError),
+    Blas(CublasError),
+    ExpectedIllegalAddressAccess,
+}
+
+pub struct CudaDevice {
+    pub(crate) stream: Arc<CudaStream>,
+    pub(crate) blas: CudaBlas,
+    pub(crate) module: Arc<CudaModule>,
+}
+
+#[allow(unused)]
+impl Device for CudaDevice {
+    type IdType = usize;
+    type DeviceError = CudaError;
+    type BufferF32 = CudaBuffer<f32>;
+    type BufferI32 = CudaBuffer<i32>;
+
+    fn new(id: Self::IdType) -> Result<Self, Self::DeviceError> {
+        let ctx = CudaContext::new(id).map_err(CudaError::Driver)?;
+        ctx.set_blocking_synchronize().map_err(CudaError::Driver)?;
+        let stream = ctx.default_stream();
+        let blas = CudaBlas::new(stream.clone()).map_err(CudaError::Blas)?;
+
+        static PTX: &str = include_str!(concat!(env!("OUT_DIR"), "/kernels.ptx"));
+
+        let module = ctx.load_module(Ptx::from_src(PTX)).map_err(CudaError::Driver)?;
+
+        Ok(Self { stream, blas, module })
+    }
+
+    fn synchronise(&self) -> Result<(), Self::DeviceError> {
+        self.stream.synchronize().map_err(CudaError::Driver)
+    }
+
+    fn get_last_device_error(&self) -> Result<(), Self::DeviceError> {
+        self.synchronise()
+    }
+
+    fn sparse_affine_activate(
+        batch_size: usize,
+        stride: Option<bool>,
+        activation: DiffableFromOutput,
+        input_a: &Self::BufferF32,
+        shape_a: Shape,
+        input_b: &Self::BufferI32,
+        shape_b: Shape,
+        nnz: usize,
+        input_c: Option<&Self::BufferF32>,
+        input_c_batched: bool,
+        output: &mut Self::BufferF32,
+    ) -> OperationResult<Self::DeviceError> {
+        Err(OperationError::UnsupportedOperation)
+    }
+
+    fn backprop_sparse_affine_activate(
+        batch_size: usize,
+        stride: Option<bool>,
+        activation: DiffableFromOutput,
+        input_a: &Self::BufferF32,
+        input_a_grad: &mut Self::BufferF32,
+        shape_a: Shape,
+        input_b: &Self::BufferI32,
+        shape_b: Shape,
+        nnz: usize,
+        input_c: Option<&Self::BufferF32>,
+        input_c_grad: Option<&mut Self::BufferF32>,
+        input_c_batched: bool,
+        outputs: &Self::BufferF32,
+        output_grad: &Self::BufferF32,
+    ) -> OperationResult<Self::DeviceError> {
+        Err(OperationError::UnsupportedOperation)
+    }
+
+    fn mask(
+        batch_size: usize,
+        single_size: usize,
+        nnz: usize,
+        inputs: &Self::BufferF32,
+        masks: &Self::BufferI32,
+        outputs: &mut Self::BufferF32,
+    ) -> OperationResult<Self::DeviceError> {
+        Err(OperationError::UnsupportedOperation)
+    }
+
+    fn backprop_mask(
+        batch_size: usize,
+        single_size: usize,
+        nnz: usize,
+        output_grads: &Self::BufferF32,
+        masks: &Self::BufferI32,
+        input_grads: &mut Self::BufferF32,
+    ) -> OperationResult<Self::DeviceError> {
+        Err(OperationError::UnsupportedOperation)
+    }
+
+    fn select(
+        batch_size: usize,
+        input_size: usize,
+        output_size: usize,
+        input: &Self::BufferF32,
+        indices: &Self::BufferI32,
+        output: &mut Self::BufferF32,
+    ) -> OperationResult<Self::DeviceError> {
+        Err(OperationError::UnsupportedOperation)
+    }
+
+    fn select_backprop(
+        batch_size: usize,
+        input_size: usize,
+        output_size: usize,
+        indices: &Self::BufferI32,
+        output_grad: &Self::BufferF32,
+        input_grad: &mut Self::BufferF32,
+    ) -> OperationResult<Self::DeviceError> {
+        Err(OperationError::UnsupportedOperation)
+    }
+
+    fn gather(
+        batch_size: usize,
+        input_size: usize,
+        output_size: usize,
+        inputs: &Self::BufferF32,
+        indices: &Self::BufferI32,
+        outputs: &mut Self::BufferF32,
+    ) -> OperationResult<Self::DeviceError> {
+        Err(OperationError::UnsupportedOperation)
+    }
+
+    fn backprop_gather(
+        batch_size: usize,
+        input_size: usize,
+        output_size: usize,
+        output_grads: &Self::BufferF32,
+        indices: &Self::BufferI32,
+        input_grads: &mut Self::BufferF32,
+    ) -> OperationResult<Self::DeviceError> {
+        Err(OperationError::UnsupportedOperation)
+    }
+
+    fn softmax_across_batch(
+        batch_size: usize,
+        single_size: usize,
+        input: &Self::BufferF32,
+        output: &mut Self::BufferF32,
+    ) -> OperationResult<Self::DeviceError> {
+        Err(OperationError::UnsupportedOperation)
+    }
+
+    fn crossentropy(
+        size: usize,
+        pred: &Self::BufferF32,
+        target: &Self::BufferF32,
+        output: &mut Self::BufferF32,
+    ) -> OperationResult<Self::DeviceError> {
+        Err(OperationError::UnsupportedOperation)
+    }
+
+    fn backprop_softmax_crossentropy(
+        size: usize,
+        softmaxed: &Self::BufferF32,
+        target: &Self::BufferF32,
+        output_grad: &Self::BufferF32,
+        input_grad: &mut Self::BufferF32,
+    ) -> OperationResult<Self::DeviceError> {
+        Err(OperationError::UnsupportedOperation)
+    }
+
+    fn softmax_across_batch_masked(
+        batch_size: usize,
+        single_size: usize,
+        nnz: usize,
+        masks: &Self::BufferI32,
+        input: &Self::BufferF32,
+        output: &mut Self::BufferF32,
+    ) -> OperationResult<Self::DeviceError> {
+        Err(OperationError::UnsupportedOperation)
+    }
+
+    fn crossentropy_masked(
+        batch_size: usize,
+        single_size: usize,
+        nnz: usize,
+        masks: &Self::BufferI32,
+        pred: &Self::BufferF32,
+        target: &Self::BufferF32,
+        output: &mut Self::BufferF32,
+        error: &mut Self::BufferF32,
+    ) -> OperationResult<Self::DeviceError> {
+        Err(OperationError::UnsupportedOperation)
+    }
+
+    fn backprop_softmax_crossentropy_masked(
+        batch_size: usize,
+        single_size: usize,
+        nnz: usize,
+        masks: &Self::BufferI32,
+        softmaxed: &Self::BufferF32,
+        target: &Self::BufferF32,
+        output_grad: &Self::BufferF32,
+        input_grad: &mut Self::BufferF32,
+    ) -> OperationResult<Self::DeviceError> {
+        Err(OperationError::UnsupportedOperation)
+    }
+
+    fn sparse_to_dense(
+        batch_size: usize,
+        size: usize,
+        nnz: usize,
+        sparse: &Self::BufferI32,
+        dense: &mut Self::BufferF32,
+    ) -> OperationResult<Self::DeviceError> {
+        Err(OperationError::UnsupportedOperation)
+    }
+}

--- a/crates/bullet_cuda_backend/src/device.rs
+++ b/crates/bullet_cuda_backend/src/device.rs
@@ -1,3 +1,5 @@
+mod sparse;
+
 use std::sync::Arc;
 
 use bullet_core::{
@@ -23,6 +25,12 @@ pub struct CudaDevice {
     pub(crate) stream: Arc<CudaStream>,
     pub(crate) blas: CudaBlas,
     pub(crate) module: Arc<CudaModule>,
+}
+
+impl Default for CudaDevice {
+    fn default() -> Self {
+        Self::new(0).unwrap()
+    }
 }
 
 impl CudaDevice {
@@ -79,7 +87,19 @@ impl Device for CudaDevice {
         input_c_batched: bool,
         output: &mut Self::BufferF32,
     ) -> OperationResult<Self::DeviceError> {
-        Err(OperationError::UnsupportedOperation)
+        sparse::sparse_affine(
+            batch_size,
+            stride,
+            activation,
+            input_a,
+            shape_a,
+            input_b,
+            shape_b,
+            nnz,
+            input_c,
+            input_c_batched,
+            output,
+        )
     }
 
     fn backprop_sparse_affine_activate(
@@ -98,7 +118,22 @@ impl Device for CudaDevice {
         outputs: &Self::BufferF32,
         output_grad: &Self::BufferF32,
     ) -> OperationResult<Self::DeviceError> {
-        Err(OperationError::UnsupportedOperation)
+        sparse::backprop_sparse_affine(
+            batch_size,
+            stride,
+            activation,
+            input_a,
+            input_a_grad,
+            shape_a,
+            input_b,
+            shape_b,
+            nnz,
+            input_c,
+            input_c_grad,
+            input_c_batched,
+            outputs,
+            output_grad,
+        )
     }
 
     fn mask(

--- a/crates/bullet_cuda_backend/src/device/sparse.rs
+++ b/crates/bullet_cuda_backend/src/device/sparse.rs
@@ -1,0 +1,205 @@
+use bullet_core::{
+    backend::device::{DeviceBuffer, OperationError},
+    graph::ir::{op::DiffableFromOutput, shape::Shape},
+};
+use cudarc::driver::{LaunchConfig, PushKernelArg};
+
+use crate::CudaBuffer;
+
+use super::CudaError;
+
+pub type OperationResult = Result<(), OperationError<CudaError>>;
+
+fn activation_str(activation: DiffableFromOutput) -> &'static str {
+    match activation {
+        DiffableFromOutput::Identity => "",
+        DiffableFromOutput::ReLU => "Relu",
+        DiffableFromOutput::CReLU => "Crelu",
+        DiffableFromOutput::SCReLU => "Screlu",
+        DiffableFromOutput::SqrReLU => "SqrRelu",
+        DiffableFromOutput::Sigmoid => "Sigmoid",
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn sparse_affine(
+    batch_size: usize,
+    stride: Option<bool>,
+    activation: DiffableFromOutput,
+    input_a: &CudaBuffer<f32>,
+    shape_a: Shape,
+    input_b: &CudaBuffer<i32>,
+    shape_b: Shape,
+    nnz: usize,
+    input_c: Option<&CudaBuffer<f32>>,
+    input_c_batched: bool,
+    output: &mut CudaBuffer<f32>,
+) -> OperationResult {
+    let shape_o = shape_a * shape_b;
+
+    let (stride, offset) = if let Some(b) = stride { (2, if b { shape_a.rows() } else { 0 }) } else { (1, 0) };
+
+    if shape_a.size() > input_a.size()
+        || batch_size * nnz > input_b.size()
+        || batch_size * shape_o.size() * stride > output.size()
+    {
+        return Err(OperationError::IndexOutOfBounds);
+    }
+
+    let m = shape_a.rows() as u32;
+    let k = batch_size as u32;
+
+    let act = activation_str(activation);
+
+    const MAXIMUM_BLOCKS_Y: u32 = 32768;
+    let threads = m.min(1024);
+    let chunks = m.div_ceil(threads);
+    let ky = k.min(MAXIMUM_BLOCKS_Y);
+    let kz = k.div_ceil(MAXIMUM_BLOCKS_Y);
+    let grid_dim = (chunks, ky, kz);
+    let cfg = LaunchConfig { grid_dim, block_dim: (threads, 1, 1), shared_mem_bytes: 0 };
+
+    if let Some(c) = input_c {
+        if shape_o.size() * if input_c_batched { batch_size } else { 1 } > c.size() {
+            return Err(OperationError::IndexOutOfBounds);
+        }
+
+        let func_name = format!("SparseAffineFwd{act}");
+        let func = output.device.module.load_function(&func_name).map_err(CudaError::Driver)?;
+
+        unsafe {
+            output
+                .device
+                .stream
+                .launch_builder(&func)
+                .arg(&(stride as i32))
+                .arg(&(nnz as i32))
+                .arg(&(m as i32))
+                .arg(&(k as i32))
+                .arg(&input_c_batched)
+                .arg(&input_a.buf)
+                .arg(&input_b.buf)
+                .arg(&c.buf)
+                .arg(&mut output.buf.slice_mut(offset..))
+                .launch(cfg)
+                .map_err(CudaError::Driver)?;
+        }
+    } else {
+        let func_name = format!("SparseMatmulFwd{act}");
+        let func = output.device.module.load_function(&func_name).map_err(CudaError::Driver)?;
+
+        unsafe {
+            output
+                .device
+                .stream
+                .launch_builder(&func)
+                .arg(&(stride as i32))
+                .arg(&(nnz as i32))
+                .arg(&(m as i32))
+                .arg(&(k as i32))
+                .arg(&input_a.buf)
+                .arg(&input_b.buf)
+                .arg(&mut output.buf.slice_mut(offset..))
+                .launch(cfg)
+                .map_err(CudaError::Driver)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn backprop_sparse_affine(
+    batch_size: usize,
+    stride: Option<bool>,
+    activation: DiffableFromOutput,
+    input_a: &CudaBuffer<f32>,
+    input_a_grad: &mut CudaBuffer<f32>,
+    shape_a: Shape,
+    input_b: &CudaBuffer<i32>,
+    shape_b: Shape,
+    nnz: usize,
+    _input_c: Option<&CudaBuffer<f32>>,
+    input_c_grad: Option<&mut CudaBuffer<f32>>,
+    input_c_batched: bool,
+    outputs: &CudaBuffer<f32>,
+    output_grad: &CudaBuffer<f32>,
+) -> OperationResult {
+    let shape_o = shape_a * shape_b;
+
+    let (stride, offset) = if let Some(b) = stride { (2, if b { shape_a.rows() } else { 0 }) } else { (1, 0) };
+
+    assert_eq!(shape_b.cols(), 1);
+    assert_eq!(shape_o.cols(), 1);
+    if shape_a.size() > input_a.size()
+        || shape_a.size() > input_a_grad.size()
+        || batch_size * nnz > input_b.size()
+        || batch_size * shape_o.size() > outputs.size()
+        || batch_size * shape_o.size() * stride > output_grad.size()
+    {
+        return Err(OperationError::IndexOutOfBounds);
+    }
+
+    let m = shape_a.rows() as u32;
+    let k = batch_size as u32;
+
+    let act = activation_str(activation);
+
+    const MAXIMUM_BLOCKS_Y: u32 = 32768;
+    let threads = m.min(1024);
+    let chunks = m.div_ceil(threads);
+    let ky = k.min(MAXIMUM_BLOCKS_Y);
+    let kz = k.div_ceil(MAXIMUM_BLOCKS_Y);
+    let grid_dim = (chunks, ky, kz);
+    let cfg = LaunchConfig { grid_dim, block_dim: (threads, 1, 1), shared_mem_bytes: 0 };
+
+    if let Some(c_grad) = input_c_grad {
+        if shape_o.size() * if input_c_batched { batch_size } else { 1 } > c_grad.size() {
+            return Err(OperationError::IndexOutOfBounds);
+        }
+
+        let func_name = format!("SparseAffineBwd{act}");
+        let func = input_a.device.module.load_function(&func_name).map_err(CudaError::Driver)?;
+
+        unsafe {
+            input_a
+                .device
+                .stream
+                .launch_builder(&func)
+                .arg(&(stride as i32))
+                .arg(&(nnz as i32))
+                .arg(&(m as i32))
+                .arg(&(k as i32))
+                .arg(&input_c_batched)
+                .arg(&input_b.buf)
+                .arg(&outputs.buf.slice(offset..))
+                .arg(&output_grad.buf.slice(offset..))
+                .arg(&mut input_a_grad.buf)
+                .arg(&mut c_grad.buf)
+                .launch(cfg)
+                .map_err(CudaError::Driver)?;
+        }
+    } else {
+        let func_name = format!("SparseMatmulBwd{act}");
+        let func = input_a.device.module.load_function(&func_name).map_err(CudaError::Driver)?;
+
+        unsafe {
+            input_a
+                .device
+                .stream
+                .launch_builder(&func)
+                .arg(&(stride as i32))
+                .arg(&(nnz as i32))
+                .arg(&(m as i32))
+                .arg(&(k as i32))
+                .arg(&input_b.buf)
+                .arg(&outputs.buf.slice(offset..))
+                .arg(&output_grad.buf.slice(offset..))
+                .arg(&mut input_a_grad.buf)
+                .launch(cfg)
+                .map_err(CudaError::Driver)?;
+        }
+    };
+
+    Ok(())
+}

--- a/crates/bullet_cuda_backend/src/lib.rs
+++ b/crates/bullet_cuda_backend/src/lib.rs
@@ -1,0 +1,7 @@
+mod base;
+mod blas;
+mod buffer;
+mod device;
+
+pub use buffer::CudaBuffer;
+pub use device::{CudaDevice, CudaError};

--- a/crates/bullet_cuda_backend/src/main.rs
+++ b/crates/bullet_cuda_backend/src/main.rs
@@ -1,0 +1,9 @@
+use std::sync::Arc;
+
+use bullet_core::backend::device::Device;
+use bullet_cuda_backend::CudaDevice;
+
+fn main() {
+    let device = Arc::new(CudaDevice::new(0).unwrap());
+    device.sanity_check();
+}

--- a/crates/bullet_hip_backend/build.rs
+++ b/crates/bullet_hip_backend/build.rs
@@ -83,6 +83,8 @@ fn build_hip(out_path: &Path) {
     println!("cargo:rerun-if-changed={}", include_path_str);
 
     cc::Build::new()
+        .cargo_warnings(false)
+        .warnings(false)
         .compiler(compiler_name)
         .debug(false)
         .opt_level(3)

--- a/crates/bullet_lib/Cargo.toml
+++ b/crates/bullet_lib/Cargo.toml
@@ -12,11 +12,12 @@ edition = { workspace = true }
 [features]
 default = ["cuda"]
 cpu = []
-cuda = ["bullet_hip_backend"]
+cuda = ["bullet_cuda_backend"]
 hip = ["bullet_hip_backend", "bullet_hip_backend/hip"]
 gh-actions = ["bullet_hip_backend/gh-actions"]
 
 [dependencies]
+bullet_cuda_backend = { workspace = true, optional = true }
 bullet_hip_backend = { workspace = true, optional = true }
 bullet_core = { workspace = true }
 bulletformat = { workspace = true }

--- a/crates/bullet_lib/Cargo.toml
+++ b/crates/bullet_lib/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = { workspace = true }
 edition = { workspace = true }
 
 [features]
-default = ["cuda"]
+default = ["hip-cuda"]
 cpu = []
 cuda = ["bullet_cuda_backend"]
 hip = ["bullet_hip_backend", "bullet_hip_backend/hip"]

--- a/crates/bullet_lib/Cargo.toml
+++ b/crates/bullet_lib/Cargo.toml
@@ -14,6 +14,7 @@ default = ["cuda"]
 cpu = []
 cuda = ["bullet_cuda_backend"]
 hip = ["bullet_hip_backend", "bullet_hip_backend/hip"]
+hip-cuda = ["bullet_hip_backend"]
 gh-actions = ["bullet_hip_backend/gh-actions"]
 
 [dependencies]

--- a/crates/bullet_lib/src/lib.rs
+++ b/crates/bullet_lib/src/lib.rs
@@ -34,9 +34,9 @@ pub use bullet_core as core;
 /// `NetworkBuilder`, and then compiled into an executable `Graph`
 pub mod nn;
 
-#[cfg(all(feature = "cuda", any(feature = "cpu", feature = "hip-cuda", feature = "hip")))]
+#[cfg(all(feature = "hip-cuda", any(feature = "cpu", feature = "cuda")))]
 compile_error!(
-    "In order to use a non-cuda backend, you must pass the `--no-default-features` flag.
+    "In order to use a non-HIP backend, you must pass the `--no-default-features` flag.
 If running an example, this would be
     cargo r -r --example <example name> --features <your feature> --no-default-features
 If using bullet as a crate, it is instead

--- a/crates/bullet_lib/src/lib.rs
+++ b/crates/bullet_lib/src/lib.rs
@@ -33,3 +33,12 @@ pub use bullet_core as core;
 /// Contains the Graph API, by which neural networks are created with
 /// `NetworkBuilder`, and then compiled into an executable `Graph`
 pub mod nn;
+
+#[cfg(all(feature = "cuda", any(feature = "cpu", feature = "hip-cuda", feature = "hip")))]
+compile_error!(
+    "In order to use a non-cuda backend, you must pass the `--no-default-features` flag.
+If running an example, this would be
+    cargo r -r --example <example name> --features <your feature> --no-default-features
+If using bullet as a crate, it is instead
+    bullet_lib = { .. other stuff here .. , default-features = false }"
+);

--- a/crates/bullet_lib/src/nn.rs
+++ b/crates/bullet_lib/src/nn.rs
@@ -7,7 +7,7 @@ pub use bullet_core::graph::{
 };
 pub type Graph = bullet_core::graph::Graph<ExecutionContext>;
 
-#[cfg(all(feature = "cpu", not(feature = "hip"), not(feature = "cuda"), not(feature = "hip-cuda")))]
+#[cfg(all(feature = "cpu", not(feature = "cuda")))]
 pub use bullet_core::backend::cpu::{CpuError as DeviceError, CpuThread as ExecutionContext};
 
 #[cfg(all(any(feature = "hip", feature = "hip-cuda"), not(feature = "cpu"), not(feature = "cuda")))]

--- a/crates/bullet_lib/src/nn.rs
+++ b/crates/bullet_lib/src/nn.rs
@@ -7,13 +7,13 @@ pub use bullet_core::graph::{
 };
 pub type Graph = bullet_core::graph::Graph<ExecutionContext>;
 
-#[cfg(all(feature = "cpu", not(feature = "hip"), not(feature = "cuda")))]
+#[cfg(all(feature = "cpu", not(feature = "hip"), not(feature = "cuda"), not(feature = "hip-cuda")))]
 pub use bullet_core::backend::cpu::{CpuError as DeviceError, CpuThread as ExecutionContext};
 
-#[cfg(all(feature = "hip", not(feature = "cpu"), not(feature = "cuda")))]
+#[cfg(all(any(feature = "hip", feature = "hip-cuda"), not(feature = "cpu"), not(feature = "cuda")))]
 pub use bullet_hip_backend::{DeviceError, ExecutionContext};
 
-#[cfg(all(feature = "cuda", not(feature = "cpu"), not(feature = "hip")))]
+#[cfg(feature = "cuda")]
 pub use bullet_cuda_backend::{CudaDevice as ExecutionContext, CudaError as DeviceError};
 
 pub mod optimiser {

--- a/crates/bullet_lib/src/nn.rs
+++ b/crates/bullet_lib/src/nn.rs
@@ -7,11 +7,14 @@ pub use bullet_core::graph::{
 };
 pub type Graph = bullet_core::graph::Graph<ExecutionContext>;
 
-#[cfg(feature = "cpu")]
+#[cfg(all(feature = "cpu", not(feature = "hip"), not(feature = "cuda")))]
 pub use bullet_core::backend::cpu::{CpuError as DeviceError, CpuThread as ExecutionContext};
 
-#[cfg(not(feature = "cpu"))]
+#[cfg(all(feature = "hip", not(feature = "cpu"), not(feature = "cuda")))]
 pub use bullet_hip_backend::{DeviceError, ExecutionContext};
+
+#[cfg(all(feature = "cuda", not(feature = "cpu"), not(feature = "hip")))]
+pub use bullet_cuda_backend::{CudaDevice as ExecutionContext, CudaError as DeviceError};
 
 pub mod optimiser {
     use crate::nn::ExecutionContext;

--- a/docs/2-getting-started.md
+++ b/docs/2-getting-started.md
@@ -41,7 +41,7 @@ Building `bullet` requires a C++ compiler (which will be invoked by `nvcc` or `h
 #### CUDA
 The default backend when compiling `bullet_lib`.
 - Install the [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit)
-- CUDA version >=12.2 is required.
+- Recommended CUDA version >=12.2 (lower versions can work)
 - The `CUDA_PATH` environment variable must be set to the CUDA install location (should contain the `bin`, `lib` and `include` directories)
 - The system `PATH` should contain `%CUDA_PATH%\bin` (or equivalent for Linux)
 


### PR DESCRIPTION
Closes #265

The default backend is hip-cuda still because not all operations are implemented in the new CUDA backend, and there is some slight inexplicable slowdown somewhere that needs to be resolved.