### PR TITLE
Search for operator fusion in forward order

### DIFF
--- a/crates/bullet_core/src/graph/ir.rs
+++ b/crates/bullet_core/src/graph/ir.rs
@@ -219,7 +219,7 @@ impl GraphIR {
     }
 
     fn try_fusion_pass(&mut self) -> Result<bool, GraphIRError> {
-        for node in (0..self.nodes.len()).rev() {
+        for node in 0..self.nodes.len() {
             if self.get(node).is_ok() {
                 if let Some(mut desc) = fusion::search_for_fusion(self, node)? {
                     desc.eliminated.push(node);


### PR DESCRIPTION
Was previously searching through graph nodes in reverse order