### PR TITLE
Fix training log when using few batches per superbatch

### DIFF
--- a/crates/bullet_lib/src/trainer.rs
+++ b/crates/bullet_lib/src/trainer.rs
@@ -194,8 +194,9 @@ pub trait NetworkTrainer {
 
             curr_batch += 1;
 
-            if curr_batch % 32 == 0 {
-                prev32_loss /= 32.0;
+            if curr_batch % 32 == 0 || (steps.batches_per_superbatch < 32 && curr_batch == steps.batches_per_superbatch)
+            {
+                prev32_loss /= 32.0_f32.min(steps.batches_per_superbatch as f32);
 
                 error_record.push((superbatch, curr_batch, prev32_loss));
 


### PR DESCRIPTION
I keep running into empty training logs because of how I do training, and after having no log from a 12 hour training, I got annoyed enough to make a fix.