### PR TITLE
Update `viriformat` to 2.0.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,9 +527,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "viriformat"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872cedc83d2636c82eb3e8cb2a49164108e02fad8add95e26d80d3ccc23268fe"
+checksum = "2e6552e7cd7b872fba8fefb429f48605feea8f6948f01cd2ae2e8047122b8c16"
 dependencies = [
  "anyhow",
  "arrayvec",

--- a/crates/bullet_lib/Cargo.toml
+++ b/crates/bullet_lib/Cargo.toml
@@ -24,7 +24,7 @@ bullet_core = { workspace = true }
 bulletformat = { workspace = true }
 montyformat = { workspace = true }
 sfbinpack = "0.4.1"
-viriformat = "1.2.0"
+viriformat = "2.0.0"
 
 [[example]]
 name = "advanced"

--- a/crates/bullet_utils/Cargo.toml
+++ b/crates/bullet_utils/Cargo.toml
@@ -13,4 +13,4 @@ bulletformat = { workspace = true }
 montyformat = { workspace = true }
 structopt = "0.3.26"
 anyhow = "1.0.86"
-viriformat = "1.2.0"
+viriformat = "2.0.0"


### PR DESCRIPTION
Normalises filter fields and changes from ply to material-based WDL modelling.
Many thanks to @aronpetko for doing the actual work.