### PR TITLE
Remove unwieldy size 1 arrays

### DIFF
--- a/crates/bullet_lib/src/value/loader/text.rs
+++ b/crates/bullet_lib/src/value/loader/text.rs
@@ -2,6 +2,7 @@ use std::{
     fmt::Debug,
     fs::File,
     io::{BufRead, BufReader},
+    slice,
     str::FromStr,
 };
 
@@ -9,12 +10,12 @@ use super::DataLoader;
 
 #[derive(Clone)]
 pub struct InMemoryTextLoader {
-    file_path: [String; 1],
+    file_path: String,
 }
 
 impl InMemoryTextLoader {
     pub fn new(file_path: &str) -> Self {
-        Self { file_path: [file_path.to_string()] }
+        Self { file_path: file_path.to_string() }
     }
 }
 
@@ -23,15 +24,15 @@ where
     <T as FromStr>::Err: Debug,
 {
     fn data_file_paths(&self) -> &[String] {
-        &self.file_path
+        slice::from_ref(&self.file_path)
     }
 
     fn count_positions(&self) -> Option<u64> {
-        Some(BufReader::new(File::open(&self.file_path[0]).unwrap()).lines().count() as u64)
+        Some(BufReader::new(File::open(&self.file_path).unwrap()).lines().count() as u64)
     }
 
     fn map_batches<F: FnMut(&[T]) -> bool>(&self, _: usize, batch_size: usize, mut f: F) {
-        let file = File::open(&self.file_path[0]).unwrap();
+        let file = File::open(&self.file_path).unwrap();
         let reader = BufReader::new(file);
         let data = reader.lines().map(|ln| ln.unwrap().parse::<T>().unwrap()).collect::<Vec<_>>();
 

--- a/crates/bullet_lib/src/value/loader/viribinpack.rs
+++ b/crates/bullet_lib/src/value/loader/viribinpack.rs
@@ -1,6 +1,7 @@
 use std::{
     fs::File,
     io::BufReader,
+    slice,
     sync::mpsc::{self, SyncSender},
 };
 
@@ -27,7 +28,7 @@ impl From<Filter> for ViriFilter {
 
 #[derive(Clone)]
 pub struct ViriBinpackLoader {
-    file_path: [String; 1],
+    file_path: String,
     buffer_size: usize,
     threads: usize,
     filter: ViriFilter,
@@ -36,7 +37,7 @@ pub struct ViriBinpackLoader {
 impl ViriBinpackLoader {
     pub fn new(path: &str, buffer_size_mb: usize, threads: usize, filter: impl Into<ViriFilter>) -> Self {
         Self {
-            file_path: [path.to_string(); 1],
+            file_path: path.to_string(),
             buffer_size: buffer_size_mb * 1024 * 1024 / std::mem::size_of::<ChessBoard>() / 2,
             threads,
             filter: filter.into(),
@@ -46,7 +47,7 @@ impl ViriBinpackLoader {
 
 impl DataLoader<ChessBoard> for ViriBinpackLoader {
     fn data_file_paths(&self) -> &[String] {
-        &self.file_path
+        slice::from_ref(&self.file_path)
     }
 
     fn count_positions(&self) -> Option<u64> {
@@ -57,7 +58,7 @@ impl DataLoader<ChessBoard> for ViriBinpackLoader {
         let mut shuffle_buffer = Vec::new();
         shuffle_buffer.reserve_exact(self.buffer_size);
 
-        let file_path = self.file_path[0].clone();
+        let file_path = self.file_path.clone();
         let buffer_size = self.buffer_size;
 
         let (sender, receiver) = mpsc::sync_channel::<Game>(256);


### PR DESCRIPTION
I'm guessing these were only used to be able to return them as slice references in `data_file_paths()`, but `slice::from_ref` feels like a cleaner solution here.