### PR TITLE
Pin `cudarc` to version 0.17.3

### DIFF
--- a/crates/bullet_cuda_backend/Cargo.toml
+++ b/crates/bullet_cuda_backend/Cargo.toml
@@ -14,5 +14,5 @@ nccl = ["cudarc/nccl"]
 
 [dependencies]
 acyclib = { workspace = true }
-cudarc = { version = "0.17.3", features = ["cuda-version-from-build-system"] }
+cudarc = { version = "=0.17.3", features = ["cuda-version-from-build-system"] }
 parking_lot = { workspace = true }


### PR DESCRIPTION
Unfortunately version 0.17.4 introduces a breaking change by updating NCCL bindings and unconditionally adding the all-to-all operation, which effectively upgrades the minimum requires NCCL version to 2.28.x