### PR TITLE
Bump cudarc version

### DIFF
--- a/crates/bullet_cuda_backend/Cargo.toml
+++ b/crates/bullet_cuda_backend/Cargo.toml
@@ -14,5 +14,5 @@ nccl = ["cudarc/nccl"]
 
 [dependencies]
 acyclib = { workspace = true }
-cudarc = { version = "=0.17.3", features = ["cuda-version-from-build-system"] }
+cudarc = { version = "=0.18.2", features = ["cuda-version-from-build-system"] }
 parking_lot = { workspace = true }


### PR DESCRIPTION
It seems that CUDA 13.0 doesn't work with `cudarc=0.17.3`. Is there a reason for the version pin?

```
thread 'main' panicked at .cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cudarc-0.
17.3/src/nvrtc/sys/mod.rs:660:18:
Expected symbol in library: DlSym { desc: "/opt/cuda/lib64/libnvrtc.so: undefined symbol: nvrtcGetNVVM" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Bumping the version solves the issue.