### PR TITLE
Bce logit loss

### DIFF
--- a/crates/acyclib/src/device/operation/base.rs
+++ b/crates/acyclib/src/device/operation/base.rs
@@ -127,4 +127,14 @@ pub trait BaseOperations {
         mom: &mut Self,
         vel: &mut Self,
     ) -> Result<(), Self::BaseError>;
+
+    fn bce_logit_loss_fwd(&mut self, size: usize, input: &Self, target: &Self) -> Result<(), Self::BaseError>;
+
+    fn bce_logit_loss_bwd(
+        &mut self,
+        size: usize,
+        input: &Self,
+        target: &Self,
+        grd: &Self,
+    ) -> Result<(), Self::BaseError>;
 }

--- a/crates/acyclib/src/graph/builder/node.rs
+++ b/crates/acyclib/src/graph/builder/node.rs
@@ -15,7 +15,7 @@ use crate::{
             operation::{
                 GraphIROperationCompilable,
                 affine::Matmul,
-                binary::{Concat, Select, SoftmaxCrossEntropy},
+                binary::{BCELogitLoss, Concat, Select, SoftmaxCrossEntropy},
                 nary::LinearCombination,
                 sparse::SparseAffineActivate,
                 unary::{
@@ -243,6 +243,18 @@ impl<B: BackendMarker> GraphBuilderNode<'_, B> {
 
     pub fn squared_error(self, targets: Self) -> Self {
         self.power_error(targets, 2.0)
+    }
+
+    /// Calculates the binary cross entropy loss of `self.sigmoid()` compared to `target`
+    ///
+    /// This is the recommended way to calculate a loss where the target is a 0/1 variable with probability `target`.
+    ///
+    /// This is equivalent to cross entropy loss with an implicit additional 0 as input.
+    /// This is what's used in logistic regression as a loss function.
+    ///
+    /// `self` should an unconstrained value, you should not apply an activation function.
+    pub fn bce_logit_loss(self, target: Self) -> Self {
+        self.builder.apply(BCELogitLoss { input: self.node, target: target.node })
     }
 
     #[deprecated]

--- a/examples/progression/1_simple.rs
+++ b/examples/progression/1_simple.rs
@@ -28,7 +28,7 @@ fn main() {
             SavedFormat::id("l1w").round().quantise::<i16>(64),
             SavedFormat::id("l1b").round().quantise::<i16>(255 * 64),
         ])
-        .loss_fn(|output, target| output.sigmoid().squared_error(target))
+        .loss_fn(|output, target| output.bce_logit_loss(target))
         .build(|builder, stm_inputs, ntm_inputs| {
             // weights
             let l0 = builder.new_affine("l0", 768, hl_size);

--- a/examples/progression/2_output_buckets.rs
+++ b/examples/progression/2_output_buckets.rs
@@ -32,7 +32,7 @@ fn main() {
             SavedFormat::id("l1w").round().quantise::<i16>(64).transpose(),
             SavedFormat::id("l1b").round().quantise::<i16>(255 * 64),
         ])
-        .loss_fn(|output, target| output.sigmoid().squared_error(target))
+        .loss_fn(|output, target| output.bce_logit_loss(target))
         .build(|builder, stm_inputs, ntm_inputs, output_buckets| {
             // weights
             let l0 = builder.new_affine("l0", 768, hl_size);

--- a/examples/progression/3_input_buckets.rs
+++ b/examples/progression/3_input_buckets.rs
@@ -56,7 +56,7 @@ fn main() {
             SavedFormat::id("l1w").round().quantise::<i16>(64).transpose(),
             SavedFormat::id("l1b").round().quantise::<i16>(255 * 64),
         ])
-        .loss_fn(|output, target| output.sigmoid().squared_error(target))
+        .loss_fn(|output, target| output.bce_logit_loss(target))
         .build(|builder, stm_inputs, ntm_inputs, output_buckets| {
             // input layer factoriser
             let l0f = builder.new_weights("l0f", Shape::new(hl_size, 768), InitSettings::Zeroed);

--- a/examples/progression/4_multi_layer.rs
+++ b/examples/progression/4_multi_layer.rs
@@ -62,7 +62,7 @@ fn main() {
             SavedFormat::id("l3w").transpose(),
             SavedFormat::id("l3b"),
         ])
-        .loss_fn(|output, target| output.sigmoid().squared_error(target))
+        .loss_fn(|output, target| output.bce_logit_loss(target))
         .build(|builder, stm_inputs, ntm_inputs, output_buckets| {
             // input layer factoriser
             let l0f = builder.new_weights("l0f", Shape::new(hl_size, 768), InitSettings::Zeroed);

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -43,11 +43,11 @@ fn main() {
             SavedFormat::id("l1w").round().quantise::<i16>(QB),
             SavedFormat::id("l1b").round().quantise::<i16>(QA * QB),
         ])
-        // map output into ranges [0, 1] to fit against our labels which
+        // implicitely map output into ranges [0, 1] to fit against our labels which
         // are in the same range
         // `target` == wdl * game_result + (1 - wdl) * sigmoid(search score in centipawns / SCALE)
         // where `wdl` is determined by `wdl_scheduler`
-        .loss_fn(|output, target| output.sigmoid().squared_error(target))
+        .loss_fn(|output, target| output.bce_logit_loss(target))
         // the basic `(768 -> N)x2 -> 1` inference
         .build(|builder, stm_inputs, ntm_inputs| {
             // weights


### PR DESCRIPTION
Hi, thanks for your library! I used it with great success, getting me second place in a chess-like competition (codecup.org).

One operation I missed is "binary cross entropy with logits loss" (as PyTorch calls it). To me, that is the natural thing to use as a loss function. Mean-square-error on `sigmoid(y)` leads to flat gradients if `y` is not close to zero. Cross entropy loss means introducing a second outcome, even though that's not really necessary. And the logit part is important, since that makes the gradient well-behaved under all circumstances (vs calculating `sigmoid(y)` and then doing the BCE loss directly).

I did not use CUDA, and couldn't get Rocm/HIP to work, so this is just the CPU implementation.