### PR TITLE
Support backtrace on panic

### DIFF
--- a/crates/bullet_lib/src/value/dataloader.rs
+++ b/crates/bullet_lib/src/value/dataloader.rs
@@ -36,6 +36,8 @@ where
         batch_size: usize,
         mut f: F,
     ) -> Result<(), DataLoadingError> {
+        bullet_trainer::run::install_backtrace_panic_hook();
+
         let ValueDataLoader { dataloader, steps, threads, wdl } = self;
         let start_batch = steps.batches_per_superbatch * (steps.start_superbatch - 1);
 

--- a/crates/trainer/src/lib.rs
+++ b/crates/trainer/src/lib.rs
@@ -49,6 +49,8 @@ impl<G: Gpu, O: OptimiserState<G>, S> Trainer<G, O, S> {
         dataloader: impl DataLoader,
         steps: TrainingSteps,
     ) -> Result<(), TrainerError<G>> {
+        run::install_backtrace_panic_hook();
+
         let mut batch_no = 0;
         let mut superbatch = steps.start_superbatch;
 

--- a/crates/trainer/src/optimiser.rs
+++ b/crates/trainer/src/optimiser.rs
@@ -166,6 +166,7 @@ impl<G: Gpu, S: OptimiserState<G>> Optimiser<G, S> {
     }
 
     pub fn write_to_checkpoint(&self, path: &str) -> Result<(), G::Error> {
+        crate::run::install_backtrace_panic_hook();
         let mut file = std::fs::File::create(format!("{path}/weights.bin")).unwrap();
         self.model.write_weights_into(&mut file)?;
         let map = self.state.iter().map(|(id, single)| (id.clone(), single)).collect();
@@ -173,6 +174,7 @@ impl<G: Gpu, S: OptimiserState<G>> Optimiser<G, S> {
     }
 
     pub fn load_weights_from_file(&mut self, path: &str) -> Result<(), G::Error> {
+        crate::run::install_backtrace_panic_hook();
         self.model.load_weights_from(std::fs::File::open(path).unwrap())
     }
 

--- a/crates/trainer/src/run.rs
+++ b/crates/trainer/src/run.rs
@@ -2,7 +2,13 @@ pub mod dataloader;
 pub mod logger;
 pub mod schedule;
 
-use std::{collections::BTreeMap, sync::mpsc, thread, time::Instant};
+use std::{
+    backtrace::Backtrace,
+    collections::BTreeMap,
+    sync::{Once, mpsc},
+    thread,
+    time::Instant,
+};
 
 use bullet_compiler::{model::Layout, tensor::TValue};
 use bullet_gpu::{
@@ -20,6 +26,33 @@ use crate::{
     },
 };
 
+static PANIC_HOOK: Once = Once::new();
+
+/// Installs a process-wide panic hook that prints the panicking thread, the
+/// panic message/location, and a full backtrace to stderr.
+///
+/// Training does most of its work on detached background threads (data loading)
+/// and scoped worker threads (batch preparation). When one of those panics, the
+/// main thread only observes a closed channel and exits without surfacing the
+/// cause, so the process can terminate with no visible error. This hook makes
+/// every panic — on any thread — print a backtrace, and uses
+/// [`Backtrace::force_capture`] so a trace is produced even when `RUST_BACKTRACE`
+/// is unset.
+///
+/// Idempotent: only the first call installs the hook.
+pub fn install_backtrace_panic_hook() {
+    PANIC_HOOK.call_once(|| {
+        std::panic::set_hook(Box::new(|info| {
+            let thread = thread::current();
+            let name = thread.name().unwrap_or("<unnamed>");
+            eprintln!("\n==== panic on thread '{name}' ====");
+            // `info` displays as "panicked at <loc>:\n<message>".
+            eprintln!("{info}");
+            eprintln!("backtrace:\n{}", Backtrace::force_capture());
+        }));
+    });
+}
+
 pub fn train_custom<G: Gpu, O: OptimiserState<G>, S>(
     trainer: &mut Trainer<G, O, S>,
     schedule: TrainingSchedule,
@@ -27,6 +60,8 @@ pub fn train_custom<G: Gpu, O: OptimiserState<G>, S>(
     mut batch_callback: impl FnMut(&mut Trainer<G, O, S>, usize, usize, f32),
     mut superbatch_callback: impl FnMut(&mut Trainer<G, O, S>, usize),
 ) -> Result<(), TrainerError<G>> {
+    install_backtrace_panic_hook();
+
     let timer = Instant::now();
 
     let model = &trainer.optimiser.model;


### PR DESCRIPTION
I have sometimes had bullet terminate with no error message, even though I have RUST_BACKTRACE=1. This adds support for backtrace output. Co-authored with Claude Opus 4.8.