### PR TITLE
speed up data loading

### DIFF
--- a/crates/bullet_lib/src/value.rs
+++ b/crates/bullet_lib/src/value.rs
@@ -10,7 +10,7 @@ use bullet_trainer::{
     model::{ModelEvaluator, ModelInputs, ModelInputsMapper, SavedFormat},
     optimiser::{Optimiser, OptimiserState},
     reader::{DataReader, ReadMapLoader},
-    run::{self, PreparedBatchHost, TrainingSteps, logger},
+    run::{self, TrainingSteps, logger},
 };
 
 use crate::{
@@ -92,9 +92,9 @@ where
                 cnt += 1;
             });
 
-            for j in cnt..nnz {
-                stm[j] = -1;
-                ntm[j] = -1;
+            if cnt < nnz {
+                stm[cnt] = -1;
+                ntm[cnt] = -1;
             }
 
             assert!(cnt <= nnz, "More inputs provided than the specified maximum!");
@@ -231,7 +231,7 @@ where
 
         let steps = TrainingSteps { batch_size: 1, batches_per_superbatch: 1, start_superbatch: 1, end_superbatch: 1 };
         let mapper = self.state.make_mapper(steps, 1.0, wdl::ConstantWDL { value: 1.0 });
-        let host_data = PreparedBatchHost { inputs: mapper.map(&[pos], 0, 1) };
+        let host_data = mapper.map(&[pos], 0, 1);
 
         let device_data = host_data.to_device(&self.optimiser.device()).unwrap();
 

--- a/crates/trainer/src/model/inputs.rs
+++ b/crates/trainer/src/model/inputs.rs
@@ -1,9 +1,11 @@
-use std::{collections::BTreeMap, iter::Zip, marker::PhantomData, slice::ChunksMut, sync::Arc};
+use std::{iter::Zip, marker::PhantomData, slice::ChunksMut, sync::Arc};
 
 use bullet_compiler::{
     model::{ModelBuilder, ModelNode, Shape},
     tensor::TValue,
 };
+
+use crate::run::{HostPool, PreparedBatchHost};
 
 pub struct ModelInputs<T> {
     inputs: T,
@@ -61,7 +63,7 @@ impl<T: InputType + 'static> ModelInputs<T> {
 
 pub struct ModelInputsMapper<T> {
     #[allow(clippy::type_complexity)]
-    func: Arc<dyn Fn(&[T], usize, u8) -> BTreeMap<String, TValue> + Send + Sync>,
+    func: Arc<dyn Fn(&[T], usize, u8) -> PreparedBatchHost + Send + Sync>,
     names: Vec<String>,
 }
 
@@ -79,11 +81,13 @@ impl<T: Send + Sync> ModelInputsMapper<T> {
         let names = inputs.names.clone();
         let inp = inputs.inputs.clone();
 
+        let pool = Arc::<HostPool>::default();
+
         let func = move |batch: &[T], batch_number, threads| {
             let f = &f;
             let chunk_size = batch.len().div_ceil(usize::from(threads));
 
-            let mut bufs = inp.make_bufs(batch.len());
+            let mut bufs = inp.make_bufs(batch.len(), &pool);
             let chunks = inp.chunks(&mut bufs, chunk_size);
 
             std::thread::scope(|s| {
@@ -100,13 +104,14 @@ impl<T: Send + Sync> ModelInputsMapper<T> {
 
             let mut vec = Vec::new();
             inp.append_bufs_to_vec(bufs, &mut vec);
-            names.iter().cloned().zip(vec).collect()
+            let inputs = names.iter().cloned().zip(vec).collect();
+            PreparedBatchHost::new(pool.clone(), inputs)
         };
 
         ModelInputsMapper { func: Arc::new(func), names: inputs.names.clone() }
     }
 
-    pub fn map(&self, data: &[T], batch_number: usize, threads: u8) -> BTreeMap<String, TValue> {
+    pub fn map(&self, data: &[T], batch_number: usize, threads: u8) -> PreparedBatchHost {
         (self.func)(data, batch_number, threads)
     }
 
@@ -121,7 +126,7 @@ pub trait InputType: Clone + Send + Sync + 'static {
     type Slices<'a>: 'a + Send + Sync;
     type Nodes<'a>: 'a;
 
-    fn make_bufs(&self, batch_size: usize) -> Self::Buf;
+    fn make_bufs(&self, batch_size: usize, pool: &Arc<HostPool>) -> Self::Buf;
 
     fn chunks<'a>(&self, buf: &'a mut Self::Buf, chunk_size: usize) -> Self::Chunks<'a>;
 
@@ -163,8 +168,8 @@ impl InputType for SparseInput {
     type Slices<'a> = &'a mut [i32];
     type Nodes<'a> = ModelNode<'a>;
 
-    fn make_bufs(&self, batch_size: usize) -> Self::Buf {
-        vec![0; self.nnz * batch_size]
+    fn make_bufs(&self, batch_size: usize, pool: &Arc<HostPool>) -> Self::Buf {
+        pool.take_i32(self.nnz * batch_size)
     }
 
     fn chunks<'a>(&self, buf: &'a mut Self::Buf, chunk_size: usize) -> Self::Chunks<'a> {
@@ -190,8 +195,10 @@ impl InputType for DenseInput<f32> {
     type Slices<'a> = &'a mut [f32];
     type Nodes<'a> = ModelNode<'a>;
 
-    fn make_bufs(&self, batch_size: usize) -> Self::Buf {
-        vec![0.0; self.shape.size() * batch_size]
+    fn make_bufs(&self, batch_size: usize, pool: &Arc<HostPool>) -> Self::Buf {
+        let mut buf = pool.take_f32(self.shape.size() * batch_size);
+        buf.fill(0.0);
+        buf
     }
 
     fn chunks<'a>(&self, buf: &'a mut Self::Buf, chunk_size: usize) -> Self::Chunks<'a> {
@@ -217,8 +224,8 @@ impl<T: InputType, U: InputType> InputType for (T, U) {
     type Slices<'a> = (T::Slices<'a>, U::Slices<'a>);
     type Nodes<'a> = (T::Nodes<'a>, U::Nodes<'a>);
 
-    fn make_bufs(&self, batch_size: usize) -> Self::Buf {
-        (self.0.make_bufs(batch_size), self.1.make_bufs(batch_size))
+    fn make_bufs(&self, batch_size: usize, pool: &Arc<HostPool>) -> Self::Buf {
+        (self.0.make_bufs(batch_size, pool), self.1.make_bufs(batch_size, pool))
     }
 
     fn chunks<'a>(&self, buf: &'a mut Self::Buf, chunk_size: usize) -> Self::Chunks<'a> {

--- a/crates/trainer/src/reader.rs
+++ b/crates/trainer/src/reader.rs
@@ -46,7 +46,7 @@ where
                     let prepared = self.mapper.map(&incomplete_buf, batch, self.threads);
                     batch += 1;
 
-                    if f(PreparedBatchHost { inputs: prepared }) {
+                    if f(prepared) {
                         return true;
                     }
 
@@ -68,7 +68,7 @@ where
                     let prepared = self.mapper.map(data, batch, self.threads);
                     batch += 1;
 
-                    if f(PreparedBatchHost { inputs: prepared }) {
+                    if f(prepared) {
                         return true;
                     }
                 }

--- a/crates/trainer/src/run.rs
+++ b/crates/trainer/src/run.rs
@@ -2,7 +2,7 @@ mod dataloader;
 pub mod logger;
 mod schedule;
 
-pub use dataloader::{DataLoader, DataLoadingError, PreparedBatchHost};
+pub use dataloader::{DataLoader, DataLoadingError, HostPool, Pool, PreparedBatchHost};
 pub use schedule::{TrainingSchedule, TrainingSteps};
 
 use std::{collections::BTreeMap, sync::mpsc, thread, time::Instant};

--- a/crates/trainer/src/run.rs
+++ b/crates/trainer/src/run.rs
@@ -2,7 +2,7 @@ mod dataloader;
 pub mod logger;
 mod schedule;
 
-pub use dataloader::{DataLoader, DataLoadingError, HostPool, Pool, PreparedBatchHost};
+pub use dataloader::{DataLoader, DataLoadingError, HostPool, PreparedBatchHost};
 pub use schedule::{TrainingSchedule, TrainingSteps};
 
 use std::{collections::BTreeMap, sync::mpsc, thread, time::Instant};

--- a/crates/trainer/src/run/dataloader.rs
+++ b/crates/trainer/src/run/dataloader.rs
@@ -70,22 +70,22 @@ impl Drop for PreparedBatchHost {
 }
 
 #[derive(Default)]
-pub struct Pool<T> {
+struct Pool<T> {
     free: Mutex<Vec<T>>,
 }
 
 impl<T> Pool<T> {
-    pub fn take(&self) -> Option<T> {
+    fn take(&self) -> Option<T> {
         self.free.lock().unwrap().pop()
     }
 
-    pub fn give(&self, value: T) {
+    fn give(&self, value: T) {
         self.free.lock().unwrap().push(value);
     }
 }
 
 impl<E: Clone + Default> Pool<Vec<E>> {
-    pub fn take_vec(&self, len: usize) -> Vec<E> {
+    fn take_vec(&self, len: usize) -> Vec<E> {
         let mut value = self.take().unwrap_or_default();
         value.resize(len, E::default());
         value

--- a/crates/trainer/src/run/dataloader.rs
+++ b/crates/trainer/src/run/dataloader.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    mem,
+    sync::{Arc, Mutex},
+};
 
 use bullet_compiler::tensor::TValue;
 use bullet_gpu::{
@@ -26,9 +30,14 @@ pub trait DataLoader: Send + Sync + 'static {
 
 pub struct PreparedBatchHost {
     pub inputs: BTreeMap<String, TValue>,
+    pool: Arc<HostPool>,
 }
 
 impl PreparedBatchHost {
+    pub fn new(pool: Arc<HostPool>, inputs: BTreeMap<String, TValue>) -> Self {
+        Self { inputs, pool }
+    }
+
     pub fn copy_to_device_async<'a, G: Gpu>(
         &'a self,
         stream: &Arc<Stream<G>>,
@@ -49,5 +58,59 @@ impl PreparedBatchHost {
             .iter()
             .map(|(id, value)| Buffer::from_host(device, value).map(|tensor| (id.clone(), tensor)))
             .collect()
+    }
+}
+
+impl Drop for PreparedBatchHost {
+    fn drop(&mut self) {
+        for (_, value) in mem::take(&mut self.inputs) {
+            self.pool.give(value);
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct Pool<T> {
+    free: Mutex<Vec<T>>,
+}
+
+impl<T> Pool<T> {
+    pub fn take(&self) -> Option<T> {
+        self.free.lock().unwrap().pop()
+    }
+
+    pub fn give(&self, value: T) {
+        self.free.lock().unwrap().push(value);
+    }
+}
+
+impl<E: Clone + Default> Pool<Vec<E>> {
+    pub fn take_vec(&self, len: usize) -> Vec<E> {
+        let mut value = self.take().unwrap_or_default();
+        value.resize(len, E::default());
+        value
+    }
+}
+
+#[derive(Default)]
+pub struct HostPool {
+    i32s: Pool<Vec<i32>>,
+    f32s: Pool<Vec<f32>>,
+}
+
+impl HostPool {
+    pub fn take_i32(&self, len: usize) -> Vec<i32> {
+        self.i32s.take_vec(len)
+    }
+
+    pub fn take_f32(&self, len: usize) -> Vec<f32> {
+        self.f32s.take_vec(len)
+    }
+
+    fn give(&self, value: TValue) {
+        match value {
+            TValue::I32(v) => self.i32s.give(v),
+            TValue::F32(v) => self.f32s.give(v),
+        }
     }
 }


### PR DESCRIPTION
speed up data loading with two optimizations:
- pooling vectors for feature indices
- only write one sentinel to the arrays of feature indices

~2x speedup to data loading for @jbienvenue, ~8x faster for me with pawn pawn inputs 