### PR TITLE
Remove the need to pass nargs to get_kernel

### DIFF
--- a/crates/gpu/src/function.rs
+++ b/crates/gpu/src/function.rs
@@ -128,7 +128,7 @@ impl<G: Gpu> Function<G> {
 
                 let func = Module::new(device.clone(), source.clone())
                     .map_err(|e| IRTrace::from(format!("{e:?}\n{source}")))?
-                    .get_kernel(name, args.len())
+                    .get_kernel(name)
                     .map_err(|e| IRTrace::from(format!("{e:?}\n{source}")))?;
 
                 max_num_args = max_num_args.max(args.len());
@@ -251,7 +251,7 @@ impl<G: Gpu> Function<G> {
                         let mut args: Vec<_> =
                             args.iter().map(|&arg| ptrs.as_ptr().add(arg).cast_mut().cast()).collect();
 
-                        func.launch(&stream, *gdim, *bdim, args.as_mut_ptr(), *smem)?;
+                        func.launch(&stream, *gdim, *bdim, &mut args, *smem)?;
                     }
                     &Inst::Matmul { cfg, a, b, c } => {
                         let handle = self.blas.as_ref().unwrap();

--- a/crates/gpu/src/kernel.rs
+++ b/crates/gpu/src/kernel.rs
@@ -59,7 +59,7 @@ impl KernelSrc {
     }
 
     pub fn compile<G: Gpu>(&self, device: Arc<Device<G>>) -> Result<CompiledKernel<G>, G::Error> {
-        let kernel = Module::new(device, &self.source)?.get_kernel(&self.name, self.arg_order.len())?;
+        let kernel = Module::new(device, &self.source)?.get_kernel(&self.name)?;
 
         Ok(CompiledKernel {
             inputs: self.inputs.clone(),
@@ -175,7 +175,7 @@ impl<G: Gpu> CompiledKernel<G> {
                 unimplemented!();
             }
 
-            self.kernel.launch(&stream, self.gdim, self.bdim, args.as_ptr().cast_mut().cast(), self.smem)?;
+            self.kernel.launch(&stream, self.gdim, self.bdim, &mut args, self.smem)?;
         }
 
         for i in inputs {

--- a/crates/gpu/src/runtime.rs
+++ b/crates/gpu/src/runtime.rs
@@ -312,12 +312,12 @@ impl<G: Gpu> Module<G> {
     }
 
     /// Get kernel with given name from module
-    pub fn get_kernel(self: Arc<Self>, name: impl Into<String>, nargs: usize) -> Result<Kernel<G>, G::Error> {
+    pub fn get_kernel(self: Arc<Self>, name: impl Into<String>) -> Result<Kernel<G>, G::Error> {
         self.device.set()?;
 
         let name = name.into();
         let cname = CString::new(name.clone()).map_err(|e| format!("{e:?}"))?;
-        let kernel = unsafe { G::module_get_kernel(self.module, &cname, nargs)? };
+        let kernel = unsafe { G::module_get_kernel(self.module, &cname)? };
 
         unsafe {
             G::kernel_load(kernel)?;
@@ -361,7 +361,7 @@ impl<G: Gpu> Kernel<G> {
         stream: &Stream<G>,
         grid_dim: Dim3,
         block_size: u32,
-        args: *mut *mut c_void,
+        args: &mut [*mut c_void],
         smem: u32,
     ) -> Result<(), G::Error> {
         let o1 = stream.device.ordinal();
@@ -520,7 +520,7 @@ mod tests {
             }
         };
 
-        let kernel = Module::new(device.clone(), kernel_src)?.get_kernel("add_one", 2)?;
+        let kernel = Module::new(device.clone(), kernel_src)?.get_kernel("add_one")?;
 
         unsafe {
             let dev_src = device.malloc(16)?;
@@ -533,7 +533,7 @@ mod tests {
             args.push((&dev_src) as *const G::DevicePtr as *mut c_void);
             args.push((&dev_dst) as *const G::DevicePtr as *mut c_void);
 
-            kernel.launch(&stream, gdim, 4, args.as_mut_ptr(), 0)?;
+            kernel.launch(&stream, gdim, 4, &mut args, 0)?;
 
             stream.sync()?;
             stream.memcpy_d2h(dev_dst, host_dst.as_mut_ptr().cast(), 16)?;

--- a/crates/gpu/src/runtime/bindings.rs
+++ b/crates/gpu/src/runtime/bindings.rs
@@ -133,7 +133,7 @@ pub trait GpuBindings: 'static {
         stream: Self::Stream,
         grid_dim: Dim3,
         block_dim: Dim3,
-        args: *mut *mut c_void,
+        args: &mut [*mut c_void],
         smem: c_uint,
     ) -> Result<(), Self::Err>;
 
@@ -141,11 +141,7 @@ pub trait GpuBindings: 'static {
 
     unsafe fn module_destroy(module: Self::Module) -> Result<(), Self::Err>;
 
-    unsafe fn module_get_kernel(
-        module: Self::Module,
-        kernel_name: &CStr,
-        nargs: usize,
-    ) -> Result<Self::Kernel, Self::Err>;
+    unsafe fn module_get_kernel(module: Self::Module, kernel_name: &CStr) -> Result<Self::Kernel, Self::Err>;
 
     unsafe fn program_compile(
         source_code: &CStr,

--- a/crates/gpu/src/runtime/cuda.rs
+++ b/crates/gpu/src/runtime/cuda.rs
@@ -178,7 +178,7 @@ impl GpuBindings for Cuda {
         stream: CUstream,
         gdim: Dim3,
         bdim: Dim3,
-        args: *mut *mut c_void,
+        args: &mut [*mut c_void],
         smem: c_uint,
     ) -> CudaResult {
         error::driver(cuLaunchKernel(
@@ -191,7 +191,7 @@ impl GpuBindings for Cuda {
             bdim.z,
             smem as c_uint,
             stream,
-            args,
+            args.as_mut_ptr(),
             std::ptr::null_mut(),
         ))
     }
@@ -206,7 +206,7 @@ impl GpuBindings for Cuda {
         error::driver(cuModuleUnload(module))
     }
 
-    unsafe fn module_get_kernel(module: CUmodule, kernel_name: &CStr, _nargs: usize) -> Result<CUfunction, CudaError> {
+    unsafe fn module_get_kernel(module: CUmodule, kernel_name: &CStr) -> Result<CUfunction, CudaError> {
         let mut func = CUfunction::default();
         error::driver(cuModuleGetFunction(&mut func, module, kernel_name.as_ptr()))?;
         Ok(func)

--- a/crates/gpu/src/runtime/metal.rs
+++ b/crates/gpu/src/runtime/metal.rs
@@ -298,7 +298,6 @@ impl GpuBindings for Metal {
 
     unsafe fn kernel_destroy(kernel: u64) -> MetalResult {
         pipeline_registry().lock().unwrap().remove(&kernel);
-        kernel_arg_info().lock().unwrap().remove(&kernel);
         Ok(())
     }
 
@@ -307,7 +306,7 @@ impl GpuBindings for Metal {
         stream: u64,
         grid_dim: Dim3,
         block_dim: Dim3,
-        args: *mut *mut c_void,
+        args: &mut [*mut c_void],
         _smem: c_uint,
     ) -> MetalResult {
         autoreleasepool(|_| unsafe {
@@ -330,13 +329,7 @@ impl GpuBindings for Metal {
             let total_threads = grid_dim.x * block_dim.x;
             let buf_reg = buffer_registry().lock().unwrap();
 
-            let arg_info = kernel_arg_info().lock().unwrap();
-            let nargs = *arg_info.get(&func).ok_or_else(|| MetalError::Runtime("Kernel arg info not found".into()))?;
-
-            for index in 0..nargs {
-                let arg_ptr = *args.add(index);
-
-                // arg_ptr points to a u64 (our synthetic buffer ID)
+            for (index, &mut arg_ptr) in args.iter_mut().enumerate() {
                 let buffer_id = *(arg_ptr as *const u64);
                 let entry = buf_reg
                     .get(&buffer_id)
@@ -380,7 +373,7 @@ impl GpuBindings for Metal {
         Ok(())
     }
 
-    unsafe fn module_get_kernel(module: u64, kernel_name: &CStr, nargs: usize) -> Result<u64, MetalError> {
+    unsafe fn module_get_kernel(module: u64, kernel_name: &CStr) -> Result<u64, MetalError> {
         let name = kernel_name.to_str().map_err(|e| MetalError::Runtime(format!("{e}")))?;
         let ns_name = NSString::from_str(name);
 
@@ -399,7 +392,6 @@ impl GpuBindings for Metal {
 
         let id = next_id();
         pipeline_registry().lock().unwrap().insert(id, pipeline);
-        kernel_arg_info().lock().unwrap().insert(id, nargs);
         Ok(id)
     }
 
@@ -537,12 +529,7 @@ impl GpuBindings for Metal {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Kernel argument type tracking
-// ---------------------------------------------------------------------------
-
 lazy_static_mutex! {
-    static kernel_arg_info: HashMap<u64, usize> = HashMap::new();
     static blas_stream_map: HashMap<u64, u64> = HashMap::new();
 }
 

--- a/crates/gpu/src/runtime/mock.rs
+++ b/crates/gpu/src/runtime/mock.rs
@@ -165,7 +165,7 @@ impl GpuBindings for MockGpu {
         stream: (),
         gdim: Dim3,
         bdim: Dim3,
-        args: *mut *mut c_void,
+        args: &mut [*mut c_void],
         smem: c_uint,
     ) -> MockResult {
         Err(MSG.into())
@@ -179,7 +179,7 @@ impl GpuBindings for MockGpu {
         Ok(())
     }
 
-    unsafe fn module_get_kernel(module: (), kernel_name: &CStr, _nargs: usize) -> MockResult {
+    unsafe fn module_get_kernel(module: (), kernel_name: &CStr) -> MockResult {
         Ok(())
     }
 

--- a/crates/gpu/src/runtime/rocm.rs
+++ b/crates/gpu/src/runtime/rocm.rs
@@ -152,7 +152,7 @@ impl GpuBindings for ROCm {
         stream: hipStream,
         gdim: Dim3,
         bdim: Dim3,
-        args: *mut *mut c_void,
+        args: &mut [*mut c_void],
         smem: c_uint,
     ) -> ROCmResult {
         error::runtime(hipModuleLaunchKernel(
@@ -165,7 +165,7 @@ impl GpuBindings for ROCm {
             bdim.z,
             smem as c_uint,
             stream,
-            args,
+            args.as_mut_ptr(),
             std::ptr::null_mut(),
         ))
     }
@@ -180,11 +180,7 @@ impl GpuBindings for ROCm {
         error::runtime(hipModuleUnload(module))
     }
 
-    unsafe fn module_get_kernel(
-        module: hipModule,
-        kernel_name: &CStr,
-        _nargs: usize,
-    ) -> Result<hipFunction, ROCmError> {
+    unsafe fn module_get_kernel(module: hipModule, kernel_name: &CStr) -> Result<hipFunction, ROCmError> {
         let mut func = hipFunction::default();
         error::runtime(hipModuleGetFunction(&mut func, module, kernel_name.as_ptr()))?;
         Ok(func)


### PR DESCRIPTION
This was a bit of an ugly change introduced with Metal support for argument binding. But with some of the simplifications made during that PR, we ended up only needing to know the number of args.

By passing args through more layers as a slice, we can keep length information all the way down into the runtime and use this instead of having to pass nargs around.