### PR TITLE
Remove multithreading concepts from metal.rs

### DIFF
--- a/crates/gpu/src/runtime/metal.rs
+++ b/crates/gpu/src/runtime/metal.rs
@@ -1,13 +1,9 @@
 //! Minimal wrapper around the Metal runtime for Apple Silicon GPUs
 
 use std::{
+    cell::{Cell, RefCell},
     collections::HashMap,
     ffi::{CStr, c_char, c_int, c_uint, c_void},
-    ops::Deref,
-    sync::{
-        Mutex,
-        atomic::{AtomicU64, Ordering},
-    },
 };
 
 use objc2::AllocAnyThread;
@@ -25,58 +21,23 @@ use super::bindings::{Dim3, GpuBindings};
 use crate::runtime::Dialect;
 use crate::runtime::bindings::{DeviceProps, GemmConfig};
 
-/// ###  Safety
-///
-/// This is not safe in general
-///
-/// The only concrete type that does get constructed in this
-/// that does not also implement Send + Sync is MTLBuffer
-/// and we only use this in a safe way
-struct SendMetal<T: ?Sized>(Retained<ProtocolObject<T>>);
-
-unsafe impl<T: ?Sized> Send for SendMetal<T> {}
-unsafe impl<T: ?Sized> Sync for SendMetal<T> {}
-
-impl<T: ?Sized> Deref for SendMetal<T> {
-    type Target = ProtocolObject<T>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
+thread_local! {
+    static CURRENT_DEVICE: Cell<i32> = const { Cell::new(0) };
+    static NEXT_ID: Cell<u64> = const { Cell::new(1) };
+    static BUFFER_REGISTRY:   RefCell<HashMap<u64, Retained<ProtocolObject<dyn MTLBuffer>>>>               = RefCell::new(HashMap::new());
+    static LIBRARY_REGISTRY:  RefCell<HashMap<u64, Retained<ProtocolObject<dyn MTLLibrary>>>>              = RefCell::new(HashMap::new());
+    static DEVICE_REGISTRY:   RefCell<HashMap<i32, Retained<ProtocolObject<dyn MTLDevice>>>>               = RefCell::new(HashMap::new());
+    static QUEUE_REGISTRY:    RefCell<HashMap<u64, Retained<ProtocolObject<dyn MTLCommandQueue>>>>         = RefCell::new(HashMap::new());
+    static PIPELINE_REGISTRY: RefCell<HashMap<u64, Retained<ProtocolObject<dyn MTLComputePipelineState>>>> = RefCell::new(HashMap::new());
+    static BLAS_STREAM_MAP:   RefCell<HashMap<u64, u64>>                                                   = RefCell::new(HashMap::new());
 }
-
-struct BufferEntry {
-    buffer: SendMetal<dyn MTLBuffer>,
-    #[allow(dead_code)]
-    bytes: usize,
-}
-
-macro_rules! lazy_static_mutex {
-    ($(static $name:ident : $ty:ty = $init:expr;)*) => {
-        $(
-            fn $name() -> &'static Mutex<$ty> {
-                static INSTANCE: std::sync::OnceLock<Mutex<$ty>> = std::sync::OnceLock::new();
-                INSTANCE.get_or_init(|| Mutex::new($init))
-            }
-        )*
-    };
-}
-
-lazy_static_mutex! {
-    static buffer_registry: HashMap<u64, BufferEntry> = HashMap::new();
-    static library_registry: HashMap<u64, Retained<ProtocolObject<dyn MTLLibrary>>> = HashMap::new();
-    static device_registry: HashMap<i32, Retained<ProtocolObject<dyn MTLDevice>>> = HashMap::new();
-    static queue_registry: HashMap<u64, Retained<ProtocolObject<dyn MTLCommandQueue>>> = HashMap::new();
-    static pipeline_registry: HashMap<u64, Retained<ProtocolObject<dyn MTLComputePipelineState>>> = HashMap::new();
-}
-
-static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
 fn next_id() -> u64 {
-    NEXT_ID.fetch_add(1, Ordering::Relaxed)
-}
-
-thread_local! {
-    static CURRENT_DEVICE: std::cell::Cell<i32> = const { std::cell::Cell::new(0) };
+    NEXT_ID.with(|n| {
+        let id = n.get();
+        n.set(id + 1);
+        id
+    })
 }
 
 /// Returns a raw pointer to the current Metal device.
@@ -87,7 +48,7 @@ thread_local! {
 /// pointer remains valid for the lifetime of the program
 unsafe fn current_device() -> *const ProtocolObject<dyn MTLDevice> {
     let ordinal = CURRENT_DEVICE.with(|c| c.get());
-    Retained::as_ptr(device_registry().lock().unwrap().get(&ordinal).expect("Metal device not initialised"))
+    DEVICE_REGISTRY.with_borrow(|r| Retained::as_ptr(r.get(&ordinal).expect("Metal device not initialised")))
 }
 
 /// Marker for the Metal runtime
@@ -99,20 +60,19 @@ pub struct Metal;
 pub enum MetalError {
     Runtime(String),
     Compile(String),
-    Message(String),
 }
 
 impl std::fmt::Display for MetalError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Runtime(s) | Self::Compile(s) | Self::Message(s) => write!(f, "{s}"),
+            Self::Runtime(s) | Self::Compile(s) => write!(f, "{s}"),
         }
     }
 }
 
 impl From<String> for MetalError {
     fn from(value: String) -> Self {
-        Self::Message(value)
+        Self::Runtime(value)
     }
 }
 
@@ -136,21 +96,21 @@ impl GpuBindings for Metal {
     unsafe fn device_get(ordinal: c_int) -> Result<c_int, MetalError> {
         let device =
             MTLCreateSystemDefaultDevice().ok_or_else(|| MetalError::Runtime("No Metal device found".into()))?;
-        device_registry().lock().unwrap().insert(ordinal, device);
+        DEVICE_REGISTRY.with_borrow_mut(|r| r.insert(ordinal, device));
         Ok(ordinal)
     }
 
     unsafe fn device_props(device: c_int) -> Result<DeviceProps, MetalError> {
-        let registry = device_registry().lock().unwrap();
-        let dev = registry.get(&device).ok_or_else(|| MetalError::Runtime("Device not found".into()))?;
-
-        Ok(DeviceProps {
-            name: dev.name().to_string(),
-            warp_size: Some(32),
-            stream_mem_alloc: false,
-            vec_atomics: true,
-            arch: None,
-            dialect: Dialect::Msl,
+        DEVICE_REGISTRY.with_borrow(|r| {
+            let dev = r.get(&device).ok_or_else(|| MetalError::Runtime("Device not found".into()))?;
+            Ok(DeviceProps {
+                name: dev.name().to_string(),
+                warp_size: Some(32),
+                stream_mem_alloc: false,
+                vec_atomics: true,
+                arch: None,
+                dialect: Dialect::Msl,
+            })
         })
     }
 
@@ -178,39 +138,40 @@ impl GpuBindings for Metal {
             .newBufferWithLength_options(bytes as NSUInteger, MTLResourceOptions::StorageModeShared)
             .ok_or_else(|| MetalError::Runtime("Failed to allocate Metal buffer".into()))?;
         let id = next_id();
-        buffer_registry().lock().unwrap().insert(id, BufferEntry { buffer: SendMetal(buffer), bytes });
+        BUFFER_REGISTRY.with_borrow_mut(|r| r.insert(id, buffer));
         Ok(id)
     }
 
     unsafe fn context_free(dev_ptr: u64) -> MetalResult {
-        buffer_registry()
-            .lock()
-            .unwrap()
-            .remove(&dev_ptr)
+        BUFFER_REGISTRY
+            .with_borrow_mut(|r| r.remove(&dev_ptr))
             .ok_or_else(|| MetalError::Runtime(format!("Buffer {dev_ptr} not found")))?;
         Ok(())
     }
 
     unsafe fn context_memset(dev_ptr: u64, bytes: usize, value: u8) -> MetalResult {
-        let registry = buffer_registry().lock().unwrap();
-        let entry = registry.get(&dev_ptr).ok_or_else(|| MetalError::Runtime(format!("Buffer {dev_ptr} not found")))?;
-        let ptr = entry.buffer.contents().as_ptr() as *mut u8;
+        let ptr = BUFFER_REGISTRY.with_borrow(|r| {
+            let entry = r.get(&dev_ptr).ok_or_else(|| MetalError::Runtime(format!("Buffer {dev_ptr} not found")))?;
+            Ok::<_, MetalError>(entry.contents().as_ptr() as *mut u8)
+        })?;
         std::ptr::write_bytes(ptr, value, bytes);
         Ok(())
     }
 
     unsafe fn context_memcpy_d2h(dst: *mut c_void, src: u64, bytes: usize) -> MetalResult {
-        let registry = buffer_registry().lock().unwrap();
-        let entry = registry.get(&src).ok_or_else(|| MetalError::Runtime(format!("Buffer {src} not found")))?;
-        let src_ptr = entry.buffer.contents().as_ptr() as *const u8;
+        let src_ptr = BUFFER_REGISTRY.with_borrow(|r| {
+            let entry = r.get(&src).ok_or_else(|| MetalError::Runtime(format!("Buffer {src} not found")))?;
+            Ok::<_, MetalError>(entry.contents().as_ptr() as *const u8)
+        })?;
         std::ptr::copy_nonoverlapping(src_ptr, dst as *mut u8, bytes);
         Ok(())
     }
 
     unsafe fn context_memcpy_h2d(dst: u64, src: *const c_void, bytes: usize) -> MetalResult {
-        let registry = buffer_registry().lock().unwrap();
-        let entry = registry.get(&dst).ok_or_else(|| MetalError::Runtime(format!("Buffer {dst} not found")))?;
-        let dst_ptr = entry.buffer.contents().as_ptr();
+        let dst_ptr = BUFFER_REGISTRY.with_borrow(|r| {
+            let entry = r.get(&dst).ok_or_else(|| MetalError::Runtime(format!("Buffer {dst} not found")))?;
+            Ok::<_, MetalError>(entry.contents().as_ptr())
+        })?;
         std::ptr::copy_nonoverlapping(src as *const u8, dst_ptr as *mut u8, bytes);
         Ok(())
     }
@@ -220,22 +181,21 @@ impl GpuBindings for Metal {
         let queue =
             device.newCommandQueue().ok_or_else(|| MetalError::Runtime("Failed to create command queue".into()))?;
         let id = next_id();
-        queue_registry().lock().unwrap().insert(id, queue);
+        QUEUE_REGISTRY.with_borrow_mut(|r| r.insert(id, queue));
         Ok(id)
     }
 
     unsafe fn stream_destroy(stream: u64) -> MetalResult {
-        queue_registry().lock().unwrap().remove(&stream);
+        QUEUE_REGISTRY.with_borrow_mut(|r| r.remove(&stream));
         Ok(())
     }
 
     unsafe fn stream_sync(stream: u64) -> MetalResult {
         autoreleasepool(|_| {
-            let command_buffer = {
-                let registry = queue_registry().lock().unwrap();
-                let queue = registry.get(&stream).ok_or_else(|| MetalError::Runtime("Stream not found".into()))?;
-                queue.commandBuffer().ok_or_else(|| MetalError::Runtime("Failed to create command buffer".into()))?
-            };
+            let command_buffer = QUEUE_REGISTRY.with_borrow(|r| {
+                let queue = r.get(&stream).ok_or_else(|| MetalError::Runtime("Stream not found".into()))?;
+                queue.commandBuffer().ok_or_else(|| MetalError::Runtime("Failed to create command buffer".into()))
+            })?;
             command_buffer.commit();
             command_buffer.waitUntilCompleted();
             Ok(())
@@ -267,7 +227,7 @@ impl GpuBindings for Metal {
     }
 
     unsafe fn kernel_destroy(kernel: u64) -> MetalResult {
-        pipeline_registry().lock().unwrap().remove(&kernel);
+        PIPELINE_REGISTRY.with_borrow_mut(|r| r.remove(&kernel));
         Ok(())
     }
 
@@ -280,32 +240,33 @@ impl GpuBindings for Metal {
         _smem: c_uint,
     ) -> MetalResult {
         autoreleasepool(|_| unsafe {
-            let command_buffer = {
-                let queue_reg = queue_registry().lock().unwrap();
-                let queue = queue_reg.get(&stream).ok_or_else(|| MetalError::Runtime("Stream not found".into()))?;
-                queue.commandBuffer().ok_or_else(|| MetalError::Runtime("Failed to create command buffer".into()))?
-            };
+            let command_buffer = QUEUE_REGISTRY.with_borrow(|r| {
+                let queue = r.get(&stream).ok_or_else(|| MetalError::Runtime("Stream not found".into()))?;
+                queue.commandBuffer().ok_or_else(|| MetalError::Runtime("Failed to create command buffer".into()))
+            })?;
 
             let encoder = command_buffer
                 .computeCommandEncoder()
                 .ok_or_else(|| MetalError::Runtime("Failed to create compute encoder".into()))?;
 
-            {
-                let pipeline_reg = pipeline_registry().lock().unwrap();
-                let pipeline = pipeline_reg.get(&func).ok_or_else(|| MetalError::Runtime("Kernel not found".into()))?;
+            PIPELINE_REGISTRY.with_borrow(|r| {
+                let pipeline = r.get(&func).ok_or_else(|| MetalError::Runtime("Kernel not found".into()))?;
                 encoder.setComputePipelineState(pipeline);
-            }
+                Ok::<(), MetalError>(())
+            })?;
 
             let total_threads = grid_dim.x * block_dim.x;
-            let buf_reg = buffer_registry().lock().unwrap();
 
-            for (index, &mut arg_ptr) in args.iter_mut().enumerate() {
-                let buffer_id = *(arg_ptr as *const u64);
-                let entry = buf_reg
-                    .get(&buffer_id)
-                    .ok_or_else(|| MetalError::Runtime(format!("Buffer {buffer_id} not found for arg {index}")))?;
-                encoder.setBuffer_offset_atIndex(Some(&*entry.buffer), 0, index as NSUInteger);
-            }
+            BUFFER_REGISTRY.with_borrow(|buf_reg| {
+                for (index, &mut arg_ptr) in args.iter_mut().enumerate() {
+                    let buffer_id = *(arg_ptr as *const u64);
+                    let entry = buf_reg
+                        .get(&buffer_id)
+                        .ok_or_else(|| MetalError::Runtime(format!("Buffer {buffer_id} not found for arg {index}")))?;
+                    encoder.setBuffer_offset_atIndex(Some(&*entry), 0, index as NSUInteger);
+                }
+                Ok::<(), MetalError>(())
+            })?;
 
             let threads_per_grid = MTLSize {
                 width: (total_threads) as NSUInteger,
@@ -327,16 +288,11 @@ impl GpuBindings for Metal {
     }
 
     unsafe fn module_create(code: *const c_void) -> Result<u64, MetalError> {
-        let library_id = *(code as *const u64);
-        let reg = library_registry().lock().unwrap();
-        if !reg.contains_key(&library_id) {
-            return Err(MetalError::Runtime("Library not found in registry".into()));
-        }
-        Ok(library_id)
+        Ok(*(code as *const u64))
     }
 
     unsafe fn module_destroy(module: u64) -> MetalResult {
-        library_registry().lock().unwrap().remove(&module);
+        LIBRARY_REGISTRY.with_borrow_mut(|r| r.remove(&module));
         Ok(())
     }
 
@@ -344,13 +300,12 @@ impl GpuBindings for Metal {
         let name = kernel_name.to_str().map_err(|e| MetalError::Runtime(format!("{e}")))?;
         let ns_name = NSString::from_str(name);
 
-        let function = {
-            let lib_reg = library_registry().lock().unwrap();
-            let library = lib_reg.get(&module).ok_or_else(|| MetalError::Runtime("Module/library not found".into()))?;
+        let function = LIBRARY_REGISTRY.with_borrow(|r| {
+            let library = r.get(&module).ok_or_else(|| MetalError::Runtime("Module/library not found".into()))?;
             library
                 .newFunctionWithName(&ns_name)
-                .ok_or_else(|| MetalError::Runtime(format!("Function '{name}' not found in library")))?
-        };
+                .ok_or_else(|| MetalError::Runtime(format!("Function '{name}' not found in library")))
+        })?;
 
         let device = &*current_device();
         let pipeline = device
@@ -358,7 +313,7 @@ impl GpuBindings for Metal {
             .map_err(|e| MetalError::Compile(format!("Failed to create pipeline: {}", e.localizedDescription())))?;
 
         let id = next_id();
-        pipeline_registry().lock().unwrap().insert(id, pipeline);
+        PIPELINE_REGISTRY.with_borrow_mut(|r| r.insert(id, pipeline));
         Ok(id)
     }
 
@@ -377,7 +332,7 @@ impl GpuBindings for Metal {
             .map_err(|e| MetalError::Compile(format!("MSL compilation failed: {}", e.localizedDescription())))?;
 
         let id = next_id();
-        library_registry().lock().unwrap().insert(id, library);
+        LIBRARY_REGISTRY.with_borrow_mut(|r| r.insert(id, library));
 
         let id_bytes = id.to_ne_bytes();
         let result: Vec<c_char> = id_bytes.iter().map(|&b| b as c_char).collect();
@@ -389,12 +344,12 @@ impl GpuBindings for Metal {
     }
 
     unsafe fn blas_destroy(handle: u64) -> MetalResult {
-        blas_stream_map().lock().unwrap().remove(&handle);
+        BLAS_STREAM_MAP.with_borrow_mut(|r| r.remove(&handle));
         Ok(())
     }
 
     unsafe fn blas_set_stream(handle: u64, stream: u64) -> MetalResult {
-        blas_stream_map().lock().unwrap().insert(handle, stream);
+        BLAS_STREAM_MAP.with_borrow_mut(|r| r.insert(handle, stream));
         Ok(())
     }
 
@@ -411,17 +366,16 @@ impl GpuBindings for Metal {
         c: u64,
     ) -> MetalResult {
         autoreleasepool(|_| unsafe {
-            let stream_id = {
-                let map = blas_stream_map().lock().unwrap();
-                *map.get(&handle).ok_or_else(|| MetalError::Runtime("BLAS handle has no associated stream".into()))?
-            };
+            let stream_id = BLAS_STREAM_MAP.with_borrow(|r| {
+                r.get(&handle)
+                    .copied()
+                    .ok_or_else(|| MetalError::Runtime("BLAS handle has no associated stream".into()))
+            })?;
 
-            let command_buffer = {
-                let queue_reg = queue_registry().lock().unwrap();
-                let queue =
-                    queue_reg.get(&stream_id).ok_or_else(|| MetalError::Runtime("Stream not found for BLAS".into()))?;
-                queue.commandBuffer().ok_or_else(|| MetalError::Runtime("Failed to create command buffer".into()))?
-            };
+            let command_buffer = QUEUE_REGISTRY.with_borrow(|r| {
+                let queue = r.get(&stream_id).ok_or_else(|| MetalError::Runtime("Stream not found for BLAS".into()))?;
+                queue.commandBuffer().ok_or_else(|| MetalError::Runtime("Failed to create command buffer".into()))
+            })?;
 
             let m = config.m as u64;
             let n = config.n as u64;
@@ -442,11 +396,10 @@ impl GpuBindings for Metal {
 
             let device = &*current_device();
 
-            let (mat_a, mat_b, mat_c) = {
-                let buf_reg = buffer_registry().lock().unwrap();
-                let buf_a = &buf_reg.get(&a).ok_or_else(|| MetalError::Runtime("Buffer A not found".into()))?.buffer;
-                let buf_b = &buf_reg.get(&b).ok_or_else(|| MetalError::Runtime("Buffer B not found".into()))?.buffer;
-                let buf_c = &buf_reg.get(&c).ok_or_else(|| MetalError::Runtime("Buffer C not found".into()))?.buffer;
+            let (mat_a, mat_b, mat_c) = BUFFER_REGISTRY.with_borrow(|buf_reg| {
+                let buf_a = &buf_reg.get(&a).ok_or_else(|| MetalError::Runtime("Buffer A not found".into()))?;
+                let buf_b = &buf_reg.get(&b).ok_or_else(|| MetalError::Runtime("Buffer B not found".into()))?;
+                let buf_c = &buf_reg.get(&c).ok_or_else(|| MetalError::Runtime("Buffer C not found".into()))?;
 
                 let desc_a = mps_matrix_descriptor(a_rows, a_cols, lda, batch, stride_a);
                 let desc_b = mps_matrix_descriptor(b_rows, b_cols, ldb, batch, stride_b);
@@ -455,8 +408,8 @@ impl GpuBindings for Metal {
                 let mat_a = mps_matrix(buf_a, &desc_a);
                 let mat_b = mps_matrix(buf_b, &desc_b);
                 let mat_c = mps_matrix(buf_c, &desc_c);
-                (mat_a, mat_b, mat_c)
-            };
+                Ok::<_, MetalError>((mat_a, mat_b, mat_c))
+            })?;
 
             let gemm = MPSMatrixMultiplication::initWithDevice_transposeLeft_transposeRight_resultRows_resultColumns_interiorColumns_alpha_beta(
                 MPSMatrixMultiplication::alloc(),
@@ -483,10 +436,6 @@ impl GpuBindings for Metal {
     }
 }
 
-lazy_static_mutex! {
-    static blas_stream_map: HashMap<u64, u64> = HashMap::new();
-}
-
 fn mps_matrix_descriptor(
     rows: u64,
     columns: u64,
@@ -500,15 +449,15 @@ fn mps_matrix_descriptor(
                 rows as NSUInteger,
                 columns as NSUInteger,
                 matrices as NSUInteger,
-                (row_bytes * 4) as NSUInteger,
-                (matrix_bytes * 4) as NSUInteger,
+                (row_numel * 4) as NSUInteger,
+                (matrix_numel * 4) as NSUInteger,
                 MPSDataType::Float32,
             )
         } else {
             MPSMatrixDescriptor::matrixDescriptorWithRows_columns_rowBytes_dataType(
                 rows as NSUInteger,
                 columns as NSUInteger,
-                (row_bytes * 4) as NSUInteger,
+                (row_numel * 4) as NSUInteger,
                 MPSDataType::Float32,
             )
         }


### PR DESCRIPTION
The original change by Blightwidow had a lot of things wrapped in Mutex, Send, Atomic, etc. but training is single-threaded so it's all unnecessary.

This switches everything to RefCell instead. It also removes BufferEntry which was a completely unnecessary wrapper around a dyn MetalBuffer.