### PR TITLE
Speedup SF Binpack Loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d171953264e8dc3aa62757255e602e507fdd358a94e3cdacb9e481ff3a1c6b0"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +164,30 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -246,6 +276,17 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -360,6 +401,18 @@ dependencies = [
  "objc2-foundation",
  "objc2-metal",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "ppv-lite86"
@@ -499,6 +552,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,13 +626,21 @@ dependencies = [
 
 [[package]]
 name = "sfbinpack"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99348262a4e636f275f55770e5ed4492032b971b73d77cf94de16d08235ae957"
+version = "0.6.3"
+source = "git+https://github.com/Disservin/binpack-rust.git?branch=parse-chunk#521212e8cd32d32fd74af906b2fcc51bd7322047"
 dependencies = [
  "arrayvec",
+ "js-sys",
+ "raw-cpuid",
  "thiserror",
+ "wasm-bindgen",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "strsim"
@@ -754,6 +830,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,8 +626,9 @@ dependencies = [
 
 [[package]]
 name = "sfbinpack"
-version = "0.6.3"
-source = "git+https://github.com/Disservin/binpack-rust.git?branch=parse-chunk#521212e8cd32d32fd74af906b2fcc51bd7322047"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339b783069f7e64546dfa20076c7176bf23e6dcf8ece4255bf7a4e6250d24d45"
 dependencies = [
  "arrayvec",
  "js-sys",

--- a/crates/bullet_lib/Cargo.toml
+++ b/crates/bullet_lib/Cargo.toml
@@ -15,7 +15,7 @@ bullet-gpu = { workspace = true }
 bullet-trainer = { workspace = true }
 bulletformat = "1.8.0"
 montyformat = "0.9.2"
-sfbinpack = { git = "https://github.com/Disservin/binpack-rust.git", branch = "parse-chunk" }
+sfbinpack = "0.6.4"
 viriformat = "2.0.1"
 
 [features]

--- a/crates/bullet_lib/Cargo.toml
+++ b/crates/bullet_lib/Cargo.toml
@@ -15,7 +15,7 @@ bullet-gpu = { workspace = true }
 bullet-trainer = { workspace = true }
 bulletformat = "1.8.0"
 montyformat = "0.9.2"
-sfbinpack = "0.6.0"
+sfbinpack = { git = "https://github.com/Disservin/binpack-rust.git", branch = "parse-chunk" }
 viriformat = "2.0.1"
 
 [features]

--- a/crates/bullet_lib/src/value/loader/sfbinpack.rs
+++ b/crates/bullet_lib/src/value/loader/sfbinpack.rs
@@ -1,7 +1,12 @@
-use std::{fs::File, sync::mpsc, thread};
+use std::{
+    fs::File,
+    io::BufReader,
+    sync::mpsc::{self, SyncSender},
+    thread,
+};
 
 use bullet_trainer::reader::DataReader;
-use sfbinpack::CompressedTrainingDataEntryReader;
+use sfbinpack::{ChunkReader, parse_chunk, read_chunk_into};
 pub use sfbinpack::{
     TrainingDataEntry,
     chess::{
@@ -74,29 +79,38 @@ where
         let buffer_size = self.buffer_size;
         let threads = self.threads;
         let filter = self.filter.clone();
+        let reader_buffer_size = threads.max(1);
 
-        let reader_buffer_size = 16384 * threads;
-        let (reader_sender, reader_receiver) = mpsc::sync_channel::<Vec<TrainingDataEntry>>(4);
+        let (reader_sender, reader_receiver) = mpsc::sync_channel::<Vec<Vec<u8>>>(4);
         let (reader_msg_sender, reader_msg_receiver) = mpsc::sync_channel::<bool>(1);
 
         std::thread::spawn(move || {
-            let mut buffer = Vec::with_capacity(reader_buffer_size);
+            let mut games = Vec::new();
 
             'dataloading: loop {
-                for file in &file_paths {
-                    let file = File::open(file).unwrap();
-                    let mut reader = CompressedTrainingDataEntryReader::new(file).unwrap();
+                for file_path in &file_paths {
+                    let mut reader = BufReader::new(File::open(file_path.as_str()).unwrap());
 
-                    while reader.has_next() {
-                        buffer.push(reader.next());
+                    let mut chunk = Vec::new();
 
-                        if buffer.len() == reader_buffer_size || !reader.has_next() {
-                            if reader_msg_receiver.try_recv().unwrap_or(false) || reader_sender.send(buffer).is_err() {
+                    while read_chunk_into(&mut reader, &mut chunk).unwrap() {
+                        games.push(std::mem::take(&mut chunk));
+
+                        if games.len() == reader_buffer_size {
+                            if reader_msg_receiver.try_recv().unwrap_or(false) || reader_sender.send(games).is_err() {
                                 break 'dataloading;
                             }
 
-                            buffer = Vec::with_capacity(reader_buffer_size);
+                            games = Vec::new();
                         }
+                    }
+
+                    if !games.is_empty() {
+                        if reader_msg_receiver.try_recv().unwrap_or(false) || reader_sender.send(games).is_err() {
+                            break 'dataloading;
+                        }
+
+                        games = Vec::new();
                     }
                 }
             }
@@ -108,39 +122,13 @@ where
         std::thread::spawn(move || {
             let filter = &filter;
             let mut should_break = false;
-            'dataloading: while let Ok(unfiltered) = reader_receiver.recv() {
+            'dataloading: while let Ok(chunks) = reader_receiver.recv() {
                 if should_break || converted_msg_receiver.try_recv().unwrap_or(false) {
                     reader_msg_sender.send(true).unwrap();
                     break 'dataloading;
                 }
 
-                thread::scope(|s| {
-                    let chunk_size = unfiltered.len().div_ceil(threads);
-                    let mut handles = Vec::new();
-
-                    for chunk in unfiltered.chunks(chunk_size) {
-                        let this_sender = converted_sender.clone();
-                        let handle = s.spawn(move || {
-                            let mut buffer = Vec::with_capacity(chunk_size);
-
-                            for entry in chunk {
-                                if filter(entry) {
-                                    buffer.push(convert_to_bulletformat(entry));
-                                }
-                            }
-
-                            this_sender.send(buffer).is_err()
-                        });
-
-                        handles.push(handle);
-                    }
-
-                    for handle in handles {
-                        if handle.join().unwrap() {
-                            should_break = true;
-                        }
-                    }
-                });
+                should_break = convert_buffer(threads, &converted_sender, &chunks, filter);
 
                 if should_break {
                     reader_msg_sender.send(true).unwrap();
@@ -182,6 +170,48 @@ where
             }
         }
     }
+}
+
+fn convert_buffer<T>(threads: usize, sender: &SyncSender<Vec<ChessBoard>>, chunks: &[Vec<u8>], filter: &T) -> bool
+where
+    T: Fn(&TrainingDataEntry) -> bool + Sync,
+{
+    let chunk_size = chunks.len().div_ceil(threads);
+    let mut should_break = false;
+
+    thread::scope(|s| {
+        let mut handles = Vec::new();
+
+        for chunk_group in chunks.chunks(chunk_size) {
+            let this_sender = sender.clone();
+            let handle = s.spawn(move || {
+                let mut buffer = Vec::new();
+
+                for chunk in chunk_group {
+                    let mut reader = ChunkReader::default();
+
+                    while reader.has_next(chunk) {
+                        let entry = reader.next(chunk);
+                        if filter(&entry) {
+                            buffer.push(convert_to_bulletformat(&entry));
+                        }
+                    }
+                }
+
+                this_sender.send(buffer).is_err()
+            });
+
+            handles.push(handle);
+        }
+
+        for handle in handles {
+            if handle.join().unwrap() {
+                should_break = true;
+            }
+        }
+    });
+
+    should_break
 }
 
 fn shuffle(data: &mut [ChessBoard]) {

--- a/crates/bullet_lib/src/value/loader/sfbinpack.rs
+++ b/crates/bullet_lib/src/value/loader/sfbinpack.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use bullet_trainer::reader::DataReader;
-use sfbinpack::{ChunkReader, parse_chunk, read_chunk_into};
+use sfbinpack::{ChunkReader, read_chunk_into};
 pub use sfbinpack::{
     TrainingDataEntry,
     chess::{


### PR DESCRIPTION
training for a 32hl simple example network and 16 dataloader threads 
```
main sf binpack loader:

superbatch 1 | time 13.5s | running loss 0.041029 | 7381480 pos/sec | total time 16.0s
Estimated time remaining in training: 0h 10m 24s
superbatch 10 | time 15.3s | running loss 0.038549 | 6527233 pos/sec | total time 152.5s
Estimated time remaining in training: 0h 7m 37s


update-sf-binpack-loader:

superbatch 1 | time 7.5s | running loss 0.040936 | 13407972 pos/sec | total time 8.5s
Estimated time remaining in training: 0h 5m 32s
superbatch 10 | time 7.3s | running loss 0.038440 | 13634095 pos/sec | total time 74.9s
Estimated time remaining in training: 0h 3m 44s


viriformat:

superbatch 1 | time 8.4s | running loss 0.047359 | 11911028 pos/sec | total time 9.7s
Estimated time remaining in training: 0h 6m 18s
superbatch 10 | time 7.4s | running loss 0.043361 | 13527347 pos/sec | total time 77.2s
Estimated time remaining in training: 0h 3m 51s
```