### PR TITLE
replace hand-rolled rng with oorandom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "anyhow",
  "bulletformat",
  "montyformat",
+ "oorandom",
  "structopt",
  "viriformat",
 ]
@@ -106,6 +107,7 @@ dependencies = [
  "bullet-trainer",
  "bulletformat",
  "montyformat",
+ "oorandom",
  "sfbinpack",
  "viriformat",
 ]
@@ -407,6 +409,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "pin-project-lite"

--- a/crates/bullet_lib/Cargo.toml
+++ b/crates/bullet_lib/Cargo.toml
@@ -15,6 +15,7 @@ bullet-gpu = { workspace = true }
 bullet-trainer = { workspace = true }
 bulletformat = "1.8.0"
 montyformat = "0.9.2"
+oorandom = "11.1.5"
 sfbinpack = "0.6.4"
 viriformat = "2.0.1"
 

--- a/crates/bullet_lib/src/value/loader/montybinpack.rs
+++ b/crates/bullet_lib/src/value/loader/montybinpack.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::game::formats::bulletformat::ChessBoard;
 
-use super::rng::SimpleRand;
+use super::rng::seeded_rng;
 
 use bullet_trainer::reader::DataReader;
 use montyformat::{
@@ -177,10 +177,10 @@ fn parse_into_buffer<T: Fn(&Position, Move, i16, f32) -> bool>(
 }
 
 fn shuffle(data: &mut [ChessBoard]) {
-    let mut rng = SimpleRand::with_seed();
+    let mut rng = seeded_rng();
 
     for i in (0..data.len()).rev() {
-        let idx = rng.rng() as usize % (i + 1);
+        let idx = rng.rand_range(0..i as u64 + 1) as usize;
         data.swap(idx, i);
     }
 }

--- a/crates/bullet_lib/src/value/loader/rng.rs
+++ b/crates/bullet_lib/src/value/loader/rng.rs
@@ -1,19 +1,9 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-pub struct SimpleRand(u64);
+use oorandom::Rand64;
 
-impl SimpleRand {
-    pub fn with_seed() -> Self {
-        let seed = SystemTime::now().duration_since(UNIX_EPOCH).expect("Guaranteed increasing.").as_micros() as u64
-            & 0xFFFF_FFFF;
+pub fn seeded_rng() -> Rand64 {
+    let seed = SystemTime::now().duration_since(UNIX_EPOCH).expect("Guaranteed increasing.").as_micros();
 
-        Self(seed)
-    }
-
-    pub fn rng(&mut self) -> u64 {
-        self.0 ^= self.0 << 13;
-        self.0 ^= self.0 >> 7;
-        self.0 ^= self.0 << 17;
-        self.0
-    }
+    Rand64::new(seed)
 }

--- a/crates/bullet_lib/src/value/loader/sfbinpack.rs
+++ b/crates/bullet_lib/src/value/loader/sfbinpack.rs
@@ -18,7 +18,7 @@ pub use sfbinpack::{
 
 use crate::game::formats::bulletformat::ChessBoard;
 
-use super::rng::SimpleRand;
+use super::rng::seeded_rng;
 
 fn convert_to_bulletformat(entry: &TrainingDataEntry) -> ChessBoard {
     let mut bbs = [0; 8];
@@ -215,10 +215,10 @@ where
 }
 
 fn shuffle(data: &mut [ChessBoard]) {
-    let mut rng = SimpleRand::with_seed();
+    let mut rng = seeded_rng();
 
     for i in (0..data.len()).rev() {
-        let idx = rng.rng() as usize % (i + 1);
+        let idx = rng.rand_range(0..i as u64 + 1) as usize;
         data.swap(idx, i);
     }
 }

--- a/crates/bullet_lib/src/value/loader/viribinpack.rs
+++ b/crates/bullet_lib/src/value/loader/viribinpack.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::game::formats::bulletformat::ChessBoard;
 
-use super::rng::SimpleRand;
+use super::rng::seeded_rng;
 
 use bullet_trainer::reader::DataReader;
 pub use viriformat::{
@@ -210,10 +210,10 @@ fn parse_into_buffer(game: &Game, buffer: &mut Vec<ChessBoard>, filter: &ViriFil
 }
 
 fn shuffle(data: &mut [ChessBoard]) {
-    let mut rng = SimpleRand::with_seed();
+    let mut rng = seeded_rng();
 
     for i in (0..data.len()).rev() {
-        let idx = rng.rng() as usize % (i + 1);
+        let idx = rng.rand_range(0..i as u64 + 1) as usize;
         data.swap(idx, i);
     }
 }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -12,5 +12,6 @@ edition = { workspace = true }
 anyhow = "1.0.86"
 bulletformat = "1.8.0"
 montyformat = "0.9.2"
+oorandom = "11.1.5"
 structopt = "0.3.26"
 viriformat = "2.0.1"

--- a/crates/utils/src/interleave.rs
+++ b/crates/utils/src/interleave.rs
@@ -4,7 +4,7 @@ use std::{
     path::PathBuf,
 };
 
-use crate::Rand;
+use crate::seeded_rng;
 use anyhow::Context;
 use structopt::StructOpt;
 
@@ -40,10 +40,10 @@ impl InterleaveOptions {
         }
 
         let mut remaining = total;
-        let mut rng = Rand::default();
+        let mut rng = seeded_rng();
 
         while remaining > 0 {
-            let mut spot = rng.rand() as usize % remaining;
+            let mut spot = rng.rand_range(0..remaining as u64) as usize;
             let mut idx = 0;
             while streams[idx].0 < spot {
                 spot -= streams[idx].0;

--- a/crates/utils/src/main.rs
+++ b/crates/utils/src/main.rs
@@ -6,6 +6,7 @@ mod shuffle;
 mod validate;
 mod viribinpack;
 
+use oorandom::Rand64;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -31,22 +32,8 @@ fn main() -> anyhow::Result<()> {
     }
 }
 
-struct Rand(u64);
+fn seeded_rng() -> Rand64 {
+    let seed = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).expect("valid").as_nanos();
 
-impl Default for Rand {
-    fn default() -> Self {
-        Self(
-            (std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).expect("valid").as_nanos()
-                & 0xFFFF_FFFF_FFFF_FFFF) as u64,
-        )
-    }
-}
-
-impl Rand {
-    fn rand(&mut self) -> u64 {
-        self.0 ^= self.0 << 13;
-        self.0 ^= self.0 >> 7;
-        self.0 ^= self.0 << 17;
-        self.0
-    }
+    Rand64::new(seed)
 }

--- a/crates/utils/src/montybinpack/interleave.rs
+++ b/crates/utils/src/montybinpack/interleave.rs
@@ -7,7 +7,7 @@ use std::{
 use montyformat::{FastDeserialise, MontyValueFormat};
 use structopt::StructOpt;
 
-use crate::Rand;
+use crate::seeded_rng;
 
 #[derive(StructOpt)]
 pub struct InterleaveOptions {
@@ -39,7 +39,7 @@ impl InterleaveOptions {
         }
 
         let mut remaining = total;
-        let mut rng = Rand::default();
+        let mut rng = seeded_rng();
 
         const INTERVAL: u64 = 1024 * 1024 * 256;
         let mut prev = remaining / INTERVAL;
@@ -48,7 +48,7 @@ impl InterleaveOptions {
         let mut games = 0usize;
 
         while remaining > 0 {
-            let mut spot = rng.rand() % remaining;
+            let mut spot = rng.rand_range(0..remaining);
             let mut idx = 0;
             while streams[idx].0 < spot {
                 spot -= streams[idx].0;

--- a/crates/utils/src/shuffle.rs
+++ b/crates/utils/src/shuffle.rs
@@ -9,7 +9,7 @@ use anyhow::Context;
 use bulletformat::ChessBoard;
 use structopt::StructOpt;
 
-use crate::{Rand, interleave::InterleaveOptions};
+use crate::{interleave::InterleaveOptions, seeded_rng};
 
 #[derive(StructOpt)]
 pub struct ShuffleOptions {
@@ -136,10 +136,10 @@ fn shuffle_positions(data: &mut [u8]) {
 
     let len = data.len() / CHESS_BOARD_SIZE;
 
-    let mut rng = Rand::default();
+    let mut rng = seeded_rng();
 
     for i in (0..len).rev() {
-        let idx = rng.rand() as usize % (i + 1);
+        let idx = rng.rand_range(0..i as u64 + 1) as usize;
         for j in 0..CHESS_BOARD_SIZE {
             data.swap(CHESS_BOARD_SIZE * idx + j, CHESS_BOARD_SIZE * i + j);
         }

--- a/crates/utils/src/viribinpack/interleave.rs
+++ b/crates/utils/src/viribinpack/interleave.rs
@@ -7,7 +7,7 @@ use std::{
 use structopt::StructOpt;
 use viriformat::dataformat::Game;
 
-use crate::Rand;
+use crate::seeded_rng;
 
 #[derive(StructOpt)]
 pub struct InterleaveOptions {
@@ -44,7 +44,7 @@ impl InterleaveOptions {
         }
 
         let mut remaining = total;
-        let mut rng = Rand::default();
+        let mut rng = seeded_rng();
 
         const INTERVAL: u64 = 1024 * 1024 * 256;
         let mut prev = remaining / INTERVAL;
@@ -53,7 +53,7 @@ impl InterleaveOptions {
         let mut games = 0usize;
 
         while remaining > 0 {
-            let mut spot = rng.rand() % remaining;
+            let mut spot = rng.rand_range(0..remaining);
             let mut idx = 0;
             while streams[idx].0 < spot {
                 spot -= streams[idx].0;


### PR DESCRIPTION
my motivation for doing this is (A) to be relying on a very high-quality RNG and (B) to make absolutely sure that things like interleaving & shuffling don’t suffer from bias by using an implemenation based on lemire’s range algorithm (https://lemire.me/blog/2024/08/17/faster-random-integer-generation-with-batching/)